### PR TITLE
Bring code from `conda/conda`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, Anaconda, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+This work also includes code borrowed from mamba.utils v0.19, licensed as BSD 3-Clause

--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
 # conda-libmamba-solver
+
+<!-- TODO: Needs to be updated for the new namespaces -->
+
+## Trying solvers
+
+The new libmamba integrations are experimental, but you can get a taste of how they are working
+so far by following these instructions.
+
+1. Clone `conda/conda` and checkout the branch you want to try. `poc-libsolv` is the "stable
+feature branch", but there might be other ones that are interesting to test. Check the opened
+PRs to see.
+
+```
+git clone https://github.com/conda/conda
+cd conda/
+git checkout poc-libsolv
+```
+
+2. Build the Docker image:
+
+```
+docker compose build --no-cache interactive
+```
+
+3. Run the interactive console. This will preinitialize the image for `conda` in `dev` mode,
+which means that:
+    * The `conda` repository will be mounted to `/opt/conda-src``
+    * The default `base` environment will run off this development install of `conda`!
+
+```
+docker compose run interactive
+```
+
+4. Now you can experiment different things. `--dry-run` is specially useful to check how different
+solvers interact. The main switch you need to take care of is the _solver logic_ option:
+
+```bash
+# Using default (classic) solver
+$ conda create -n demo scipy --dry-run
+# This is equivalent
+$ CONDA_SOLVER_LOGIC=classic conda create -n demo scipy --dry-run
+# Using original libmamba integrations
+$ CONDA_SOLVER_LOGIC=libmamba conda create -n demo scipy --dry-run
+# Using refactored libmamba
+$ CONDA_SOLVER_LOGIC=libmamba2 conda create -n demo scipy --dry-run
+```
+
+> `mamba` is also available in case you want to compare our integrations with the original Mamba
+> project: `mamba create -n demo scipy --dry-run`
+
+5. Use `time` to measure how different solvers perform. Take into account that repodata
+   retrieval is cached across attempts, so only consider timings after warming that up:
+
+```bash
+# Warm up the repodata cache
+$ conda create -n demo scipy --dry-run
+# Timings for original solver
+$ time env CONDA_SOLVER_LOGIC=classic conda create -n demo scipy --dry-run
+# Timings for libmamba integration
+$ time env CONDA_SOLVER_LOGIC=libmamba2 conda create -n demo scipy --dry-run
+```
+
+> `conda create` commands will have similar performance because it's a very simple action! However,
+> things change once you factor in existing environments. Simple commands like `conda install scipy`
+> show ~2x speedups already.
+
+6. If you need extra details on _why_ solvers are working in that way, increase verbosity. Output
+might get too long for your terminal buffer, so consider using a pager like `less`:
+
+```bash
+# Verbosity can be 0, 1, 2 or 3
+$ CONDA_VERBOSITY=1 CONDA_SOLVER_LOGIC=libmamba conda create -n demo scipy --dry-run  2>&1 | less
+```

--- a/conda_libmamba_solver/__init__.py
+++ b/conda_libmamba_solver/__init__.py
@@ -1,0 +1,10 @@
+
+from .libmamba import LibMambaSolver
+from .libmamba2 import LibMambaSolver2
+
+
+def _get_solver_logic(key=None):
+    return {
+        "libmamba": LibMambaSolver,
+        "libmamba2": LibMambaSolver2,
+    }[key]

--- a/conda_libmamba_solver/libmamba.py
+++ b/conda_libmamba_solver/libmamba.py
@@ -1,0 +1,1177 @@
+from itertools import chain
+from collections import defaultdict, OrderedDict
+from logging import getLogger
+
+from conda.core.index import _supplement_index_with_system
+from conda.core.prefix_data import PrefixData
+from conda import CondaError
+from conda._vendor.boltons.setutils import IndexedSet
+from conda._vendor.toolz import concatv, groupby
+from conda.base.constants import DepsModifier, UpdateModifier, ChannelPriority
+from conda.base.context import context
+from conda.common.constants import NULL
+from conda.common.path import get_major_minor_version, paths_equal
+from conda.common.url import (
+    escape_channel_url,
+    split_anaconda_token,
+    remove_auth,
+)
+from conda.exceptions import (
+    PackagesNotFoundError,
+    SpecsConfigurationConflictError,
+    RawStrUnsatisfiableError,
+)
+from conda.history import History
+from conda.models.channel import Channel
+from conda.models.match_spec import MatchSpec
+from conda.models.prefix_graph import PrefixGraph
+from conda.models.version import VersionOrder
+from conda.core.solve import Solver, get_pinned_specs
+
+
+log = getLogger(__name__)
+
+
+class LibMambaSolver(Solver):
+    """
+    This alternative Solver logic wraps ``libmamba`` through their Python bindings.
+
+    We mainly replace ``Solver.solve_final_state``, quite high in the abstraction
+    tree, which means that ``conda.resolve`` and ``conda.common.logic`` are no longer
+    used here. All those bits are replaced by the logic implemented in ``libmamba`` itself.
+
+    This means that ``libmamba`` governs processes like:
+
+    - Building the SAT clauses
+    - Pruning the repodata (?) - JRG: Not sure if this happens internally or at all.
+    - Prioritizing different aspects of the solver (version, build strings, track_features...)
+    """
+
+    _uses_ssc = False
+
+    def solve_final_state(
+        self,
+        update_modifier=NULL,
+        deps_modifier=NULL,
+        prune=NULL,
+        ignore_pinned=NULL,
+        force_remove=NULL,
+        force_reinstall=NULL,
+        should_retry_solve=False,
+    ):
+        # Logic heavily based on Mamba's implementation (solver parts):
+        # https://github.com/mamba-org/mamba/blob/fe4ecc5061a49c5b400fa7e7390b679e983e8456/mamba/mamba.py#L289
+
+        if not context.json and not context.quiet:
+            print("------ USING EXPERIMENTAL LIBMAMBA INTEGRATIONS ------")
+
+        # 0. Identify strategies
+        kwargs = self._merge_signature_flags_with_context(
+            update_modifier=update_modifier,
+            deps_modifier=deps_modifier,
+            prune=prune,
+            ignore_pinned=ignore_pinned,
+            force_remove=force_remove,
+            force_reinstall=force_reinstall,
+            should_retry_solve=should_retry_solve,
+        )
+
+        # Tasks that do not require a solver can be tackled right away
+        # This returns either None (did nothing) or a final state
+        none_or_final_state = self._early_exit_tasks(
+            update_modifier=kwargs["update_modifier"],
+            force_remove=kwargs["force_remove"],
+        )
+        if none_or_final_state is not None:
+            return none_or_final_state
+
+        # These tasks DO need a solver
+        # 1. Populate repos with installed packages
+        state = self._setup_state()
+
+        # This might be too many attempts in large environments
+        # We are technically allowing as many conflicts as packages
+        # Mamba will only report one problem at a time for now, so
+        # this is a limitation
+        n_installed_pkgs = len(state["installed_pkgs"])
+        attempts = n_installed_pkgs
+        while attempts:
+            attempts -= 1
+            log.debug(
+                "Attempt number %s. Current conflicts (including learnt ones): %s",
+                n_installed_pkgs - attempts,
+                state["conflicting"],
+            )
+            result = self._solve_attempt(state, kwargs)
+            if result is not None:
+                return result
+
+        # Last attempt, we report everything installed as a conflict just in case
+        log.debug("Last attempt: reporting all installed as conflicts:")
+        state["conflicting"].update(
+            {
+                pkg.name: pkg.to_match_spec()
+                for pkg in state["conda_prefix_data"].iter_records()
+                if not pkg.is_unmanageable
+            }
+        )
+        result = self._solve_attempt(state, kwargs)
+        if result is not None:
+            return result
+
+        # If we didn't return already, raise last known issue.
+        problems = state["solver"].problems_to_str()
+        log.debug("We didn't find a solution. Reporting problems: %s", problems)
+        raise self.raise_for_problems(problems)
+
+    def _solve_attempt(self, state, kwargs):
+        # 2. Create solver and needed flags, tasks and jobs
+        self._configure_solver(
+            state,
+            update_modifier=kwargs["update_modifier"],
+            deps_modifier=kwargs["deps_modifier"],
+            ignore_pinned=kwargs["ignore_pinned"],
+            force_remove=kwargs["force_remove"],
+            force_reinstall=kwargs["force_reinstall"],
+            prune=kwargs["prune"],
+        )
+        # 3. Run the SAT solver
+        success = self._run_solver(state)
+        if not success:
+            # conflicts were reported, try again
+            # an exception will be raised from _run_solver
+            # if we end up in a conflict loop
+            log.debug("Failed attempt!")
+            return
+        # 4. Export back to conda
+        self._export_final_state(state)
+        # 5. Refine solutions depending on the value of some modifier flags
+        return self._post_solve_tasks(
+            state,
+            update_modifier=kwargs["update_modifier"],
+            deps_modifier=kwargs["deps_modifier"],
+            ignore_pinned=kwargs["ignore_pinned"],
+            force_remove=kwargs["force_remove"],
+            force_reinstall=kwargs["force_reinstall"],
+            prune=kwargs["prune"],
+        )
+
+    def _merge_signature_flags_with_context(
+        self,
+        update_modifier=NULL,
+        deps_modifier=NULL,
+        ignore_pinned=NULL,
+        force_remove=NULL,
+        force_reinstall=NULL,
+        prune=NULL,
+        should_retry_solve=False,
+    ):
+        """
+        Context options can be overriden with the signature flags.
+
+        We need this, at least, for some unit tests that change this behaviour through
+        the function signature instead of the context / env vars.
+        """
+        # Sometimes a str is passed instead of the Enum item
+        str_to_enum = {
+            "NOT_SET": DepsModifier.NOT_SET,
+            "NO_DEPS": DepsModifier.NO_DEPS,
+            "ONLY_DEPS": DepsModifier.ONLY_DEPS,
+            "SPECS_SATISFIED_SKIP_SOLVE": UpdateModifier.SPECS_SATISFIED_SKIP_SOLVE,
+            "FREEZE_INSTALLED": UpdateModifier.FREEZE_INSTALLED,
+            "UPDATE_DEPS": UpdateModifier.UPDATE_DEPS,
+            "UPDATE_SPECS": UpdateModifier.UPDATE_SPECS,
+            "UPDATE_ALL": UpdateModifier.UPDATE_ALL,
+        }
+
+        def context_if_null(name, value):
+            return getattr(context, name) if value is NULL else str_to_enum.get(value, value)
+
+        return {
+            "update_modifier": context_if_null("update_modifier", update_modifier),
+            "deps_modifier": context_if_null("deps_modifier", deps_modifier),
+            "ignore_pinned": context_if_null("ignore_pinned", ignore_pinned),
+            "force_remove": context_if_null("force_remove", force_remove),
+            "force_reinstall": context_if_null("force_reinstall", force_reinstall),
+            "prune": prune,
+            # We don't use these flags in mamba
+            # "should_retry_solve": should_retry_solve,
+        }
+
+    def _early_exit_tasks(self, update_modifier=NULL, force_remove=NULL):
+        """
+        This reimplements a chunk of code found in the Classic implementation.
+
+        See https://github.com/conda/conda/blob/9e9461760bbd71a17822/conda/core/solve.py#L239-L256
+        """
+        # force_remove is a special case where we return early
+        if self.specs_to_remove and force_remove:
+            if self.specs_to_add:
+                # This is not reachable from the CLI, but it is from the Python API
+                raise NotImplementedError("Cannot add and remove packages simultaneously.")
+            pkg_records = PrefixData(self.prefix).iter_records()
+            solution = tuple(
+                pkg_record
+                for pkg_record in pkg_records
+                if not any(spec.match(pkg_record) for spec in self.specs_to_remove)
+            )
+            return IndexedSet(PrefixGraph(solution).graph)
+
+        # Check if specs are satisfied by current environment. If they are, exit early.
+        if (
+            update_modifier == UpdateModifier.SPECS_SATISFIED_SKIP_SOLVE
+            and not self.specs_to_remove
+        ):
+            prefix_data = PrefixData(self.prefix)
+            for spec in self.specs_to_add:
+                if not next(prefix_data.query(spec), None):
+                    break
+            else:
+                # All specs match a package in the current environment.
+                # Return early, with a solution that should just be PrefixData().iter_records()
+                return IndexedSet(PrefixGraph(prefix_data.iter_records()).graph)
+
+    def _setup_state(self):
+        import libmambapy as api
+        from .libmamba_utils import load_channels, get_installed_jsonfile, init_api_context
+
+        init_api_context()
+
+        pool = api.Pool()
+        state = {}
+
+        # TODO: Check if this update-related logic is needed here too
+        # Maybe conda already handles that beforehand
+        # https://github.com/mamba-org/mamba/blob/fe4ecc5061a49c5b400fa7/mamba/mamba.py#L426-L485
+
+        installed_json_f, installed_pkgs = get_installed_jsonfile(self.prefix)
+        repos = []
+        installed = api.Repo(pool, "installed", installed_json_f.name, "")
+        installed.set_installed()
+        repos.append(installed)
+
+        # This function will populate the pool/repos with
+        # the current state of the given channels
+        # Note load_channels has a `repodata_fn` arg we are NOT using
+        # because `current_repodata.json` is not guaranteed to exist in
+        # our current implementation; we bypass that and always use the
+        # default value: repodata.json
+        subdirs = self.subdirs
+        if subdirs is NULL or not subdirs:
+            subdirs = context.subdirs
+        index = load_channels(
+            pool,
+            self._channel_urls(),
+            repos,
+            prepend=False,
+            use_local=context.use_local,
+            platform=subdirs,
+        )
+
+        state.update(
+            {
+                "pool": pool,
+                "conda_prefix_data": PrefixData(self.prefix),
+                "repos": repos,
+                "index": index,
+                "installed_pkgs": installed_pkgs,
+                "history": History(self.prefix),
+                "conflicting": TrackedDict(),
+                "specs_map": TrackedDict(),
+            }
+        )
+
+        return state
+
+    def _channel_urls(self):
+        """
+        TODO: libmambapy could handle path to url, and escaping
+        but so far we are doing it ourselves
+        """
+
+        def _channel_to_url_or_name(channel):
+            # This fixes test_activate_deactivate_modify_path_bash
+            # and other local channels (path to url) issues
+            urls = []
+            for url in channel.urls():
+                url = url.rstrip("/").rsplit("/", 1)[0]  # remove subdir
+                urls.append(escape_channel_url(url))
+            # deduplicate
+            urls = list(OrderedDict.fromkeys(urls))
+            return urls
+
+        channels = [url for c in self._channels for url in _channel_to_url_or_name(Channel(c))]
+        if context.restore_free_channel and "https://repo.anaconda.com/pkgs/free" not in channels:
+            channels.append("https://repo.anaconda.com/pkgs/free")
+
+        return tuple(channels)
+
+    def _configure_solver(
+        self,
+        state,
+        update_modifier=NULL,
+        deps_modifier=NULL,
+        ignore_pinned=NULL,
+        force_remove=NULL,
+        force_reinstall=NULL,
+        prune=NULL,
+    ):
+        if self.specs_to_remove:
+            return self._configure_solver_for_remove(state)
+        # ALl other operations are handled as an install operation
+        # Namely:
+        # - Explicit specs added by user in CLI / API
+        # - conda update --all
+        # - conda create -n empty
+        # Take into account that early exit tasks (force remove, etc)
+        # have been handled beforehand if needed
+        return self._configure_solver_for_install(
+            state,
+            update_modifier=update_modifier,
+            deps_modifier=deps_modifier,
+            ignore_pinned=ignore_pinned,
+            force_remove=force_remove,
+            force_reinstall=force_reinstall,
+            prune=prune,
+        )
+
+    def _configure_solver_for_install(
+        self,
+        state,
+        update_modifier=NULL,
+        deps_modifier=NULL,
+        ignore_pinned=NULL,
+        force_remove=NULL,
+        force_reinstall=NULL,
+        prune=NULL,
+    ):
+        import libmambapy as api
+
+        # Set different solver options
+        solver_options = [(api.SOLVER_FLAG_ALLOW_DOWNGRADE, 1)]
+        if context.channel_priority is ChannelPriority.STRICT:
+            solver_options.append((api.SOLVER_FLAG_STRICT_REPO_PRIORITY, 1))
+        state["solver"] = solver = api.Solver(state["pool"], solver_options)
+
+        # Configure jobs
+        state["specs_map"] = self._compute_specs_map(
+            state,
+            update_modifier=update_modifier,
+            deps_modifier=deps_modifier,
+            ignore_pinned=ignore_pinned,
+            force_remove=force_remove,
+            force_reinstall=force_reinstall,
+            prune=prune,
+        )
+
+        # Neuter conflicts if any (modifies specs_map in place)
+        specs_map = self._neuter_conflicts(state, ignore_pinned=ignore_pinned)
+
+        tasks = self._specs_map_to_tasks(state, specs_map)
+
+        log.debug(
+            "Invoking libmamba with tasks: %s",
+            "\n".join(
+                [f"{task_str}: {', '.join(specs)}" for (task_str, _), specs in tasks.items()]
+            ),
+        )
+
+        for (_, task_type), specs in tasks.items():
+            solver.add_jobs(sorted(specs), task_type)
+
+        return solver
+
+    def _configure_solver_for_remove(self, state):
+        # First check we are not trying to remove things that are not installed
+        installed_names = set(rec.name for rec in state["conda_prefix_data"].iter_records())
+        not_installed = set(s for s in self.specs_to_remove if s.name not in installed_names)
+        if not_installed:
+            raise PackagesNotFoundError(not_installed)
+
+        import libmambapy as api
+
+        solver_options = [
+            (api.SOLVER_FLAG_ALLOW_DOWNGRADE, 1),
+            (api.SOLVER_FLAG_ALLOW_UNINSTALL, 1),
+        ]
+        if context.channel_priority is ChannelPriority.STRICT:
+            solver_options.append((api.SOLVER_FLAG_STRICT_REPO_PRIORITY, 1))
+        solver = api.Solver(state["pool"], solver_options)
+
+        # pkgs in aggresive_update_packages should be protected too (even if not
+        # requested explicitly by the user)
+        # see https://github.com/conda/conda/blob/9e9461760bb/tests/core/test_solve.py#L520-L521
+        aggresive_updates = [
+            p.conda_build_form()
+            for p in context.aggressive_update_packages
+            if p.name in installed_names
+        ]
+        solver.add_jobs(
+            list(set(chain(self._history_specs(), aggresive_updates))),
+            api.SOLVER_USERINSTALLED,
+        )
+        specs = [s.conda_build_form() for s in self.specs_to_remove]
+        solver.add_jobs(specs, api.SOLVER_ERASE | api.SOLVER_CLEANDEPS)
+
+        state["solver"] = solver
+        return solver
+
+    def _compute_specs_map(
+        self,
+        state,
+        update_modifier=NULL,
+        deps_modifier=NULL,
+        ignore_pinned=NULL,
+        force_remove=NULL,
+        force_reinstall=NULL,
+        prune=NULL,
+    ):
+        """
+        Reimplement the logic found in super()._collect_all_metadata()
+        and super()._add_specs(), but simplified.
+        """
+        # Section 1: Expose the prefix state
+
+        # This will be our `ssc.specs_map`; a dict of names->MatchSpec that
+        # will contain the specs passed to the solver (eventually). Mamba
+        # expects a MatchSpec.conda_build_form(), but internally we will use
+        # the full object to handle things like optionality and targets.
+        specs_map = TrackedDict()
+        history = state["history"].get_requested_specs_map()
+        installed = {p.name: p for p in state["conda_prefix_data"].iter_records()}
+        pinned = {p.name: p for p in self._pinned_specs(state, ignore_pinned)}
+        conflicting = state["conflicting"]
+
+        # 1.1. Add everything found in history
+        log.debug("Adding history pins")
+        specs_map.update(history)
+        # 1.2. Protect some critical packages from being removed accidentally
+        for pkg_name in (
+            "anaconda",
+            "conda",
+            "conda-build",
+            "python.app",
+            "console_shortcut",
+            "powershell_shortcut",
+        ):
+            if pkg_name not in specs_map and state["conda_prefix_data"].get(pkg_name, None):
+                specs_map[pkg_name] = MatchSpec(pkg_name)
+
+        # 1.3. Add virtual packages so they are taken into account by the solver
+        log.debug("Adding virtual packages")
+        virtual_pkg_index = {}
+        _supplement_index_with_system(virtual_pkg_index)
+        for virtual_pkg in virtual_pkg_index.keys():
+            if virtual_pkg.name not in specs_map:
+                specs_map[virtual_pkg.name] = MatchSpec(virtual_pkg.name)
+
+        # 1.4. Go through the installed packages and...
+        log.debug("Relaxing some installed specs")
+        for pkg_name, pkg_record in installed.items():
+            name_spec = MatchSpec(pkg_name)
+            if (  # 1.4.1. History is empty. Add everything (happens with update --all)
+                not history
+                # 1.4.2. Pkg is part of the aggresive update list
+                or name_spec in context.aggressive_update_packages
+                # 1.4.3. it was installed with pip/others; treat it as a historic package
+                or pkg_record.subdir == "pypi"
+            ):
+                specs_map[pkg_name] = name_spec
+
+        # Section 2 - Here we technically consider the packages that need to be removed
+        # but we are handling that as a separate action right now - TODO?
+
+        # Section 3 - Refine specs implicitly by the prefix state
+        #
+        # 3.1. If the prefix already contain matching specs for what we have added so far,
+        # constrain these whenever possible to reduce the amount of changes
+        log.debug("Refining some installed packages...")
+        for pkg_name, pkg_spec in specs_map.items():
+            matches_for_spec = tuple(prec for prec in installed.values() if pkg_spec.match(prec))
+            if not matches_for_spec:
+                continue
+            if len(matches_for_spec) > 1:
+                raise CondaError(
+                    "Your prefix contains more than one possible match for the requested spec!\n"
+                    f"  pkg_name: {pkg_name}\n"
+                    f"  spec: {pkg_spec}\n"
+                    f"  matches_for_spec: {matches_for_spec}\n"
+                )
+            spec_in_prefix = matches_for_spec[0]
+            # 3.1.1: always update
+            if MatchSpec(pkg_name) in context.aggressive_update_packages:
+                log.debug("Relax due to aggressive_update_packages")
+                specs_map[pkg_name] = MatchSpec(pkg_name)
+            # 3.1.2: freeze
+            elif spec_in_prefix.is_unmanageable:
+                log.debug("Freeze because unmanageable")
+                # TODO: This is not the complete _should_freeze logic
+                specs_map[pkg_name] = spec_in_prefix.to_match_spec()
+            elif not history:
+                log.debug("Freeze because no history")
+                # TODO: This is not the complete _should_freeze logic
+                specs_map[pkg_name] = spec_in_prefix.to_match_spec()
+            elif pkg_name not in conflicting:
+                log.debug("Freeze because not conflicting")
+                # TODO: This is not the complete _should_freeze logic
+                specs_map[pkg_name] = spec_in_prefix.to_match_spec()
+            # 3.1.3: soft-constrain via `target`
+            elif pkg_name in history:
+                log.debug("Soft-freezing because historic")
+                specs_map[pkg_name] = MatchSpec(
+                    history[pkg_name], target=spec_in_prefix.dist_str()
+                )
+            else:
+                log.debug(
+                    "Soft-freezing because it is requested and "
+                    "already installed as a 2nd order dependency"
+                )
+                specs_map[pkg_name] = MatchSpec(pkg_name, target=spec_in_prefix.dist_str())
+
+        # Section 4: Check pinned packages
+        from mamba.repoquery import depends as mamba_depends
+
+        pin_overrides = set()
+        explicit_pool = set()
+        for spec in self.specs_to_add:
+            result = mamba_depends(spec.dist_str(), pool=state["pool"])
+            explicit_pool.update([p["name"] for p in result["result"]["pkgs"]])
+
+        specs_to_add_map = {s.name: s for s in self.specs_to_add}
+        for name, pin in pinned.items():
+            is_installed = name in installed
+            is_requested = name in specs_to_add_map
+            if is_installed and not is_requested:
+                log.debug("Pinning because installed and not requested")
+                specs_map[name] = MatchSpec(pin, optional=False)
+            elif is_requested:
+                log.debug("Pin overrides user-requested spec")
+                if specs_to_add_map[name].match(pin):
+                    log.debug(
+                        "pinned spec `%s` despite user-requested spec `%s` being present "
+                        "because pin is stricter",
+                        pin,
+                        specs_to_add_map[name],
+                    )
+                    specs_map[name] = MatchSpec(pin, optional=False)
+                    pin_overrides.add(name)
+                else:
+                    log.warn(
+                        "pinned spec %s conflicts with explicit specs (%s).  "
+                        "Overriding pinned spec.",
+                        pin,
+                        specs_to_add_map[name],
+                    )
+            elif name in explicit_pool:
+                log.debug("Pinning because this spec is part of the explicit pool")
+                specs_map[name] = MatchSpec(pin, optional=False)
+            # TODO: Not sure what this does
+            # elif installed[pin.name] & r._get_package_pool([pin]).get(pin.name, set()):
+            #     specs_map[pin.name] = MatchSpec(pin, optional=False)
+            #     pin_overrides.add(pin.name)
+
+        # Section 5: freeze everything that is not currently in conflict
+        if update_modifier == UpdateModifier.FREEZE_INSTALLED:
+            for pkg_name, pkg_record in installed.items():
+                if pkg_name not in conflicting:  # TODO
+                    log.debug("Freezing because installed and not conflicting")
+                    specs_map[pkg_name] = pkg_record.to_match_spec()
+                elif not pkg_record.is_unmanageable:
+                    log.debug("Unfreezing because conflicting...")
+                    specs_map[pkg_name] = MatchSpec(
+                        pkg_name, target=pkg_record.to_match_spec(), optional=True
+                    )
+            # log.debug("specs_map with targets: %s", specs_map)
+
+        # Section 6: Handle UPDATE_ALL
+        elif update_modifier == UpdateModifier.UPDATE_ALL:
+            new_specs_map = TrackedDict()
+            if history:
+                for spec in history:
+                    matchspec = MatchSpec(spec)
+                    if matchspec.name not in pinned:
+                        log.debug("Update all: spec is in history but not pinnned")
+                        new_specs_map[spec] = matchspec
+                    else:
+                        log.debug("Update all: spec is in history and pinnned")
+                        new_specs_map[matchspec.name] = specs_map[matchspec.name]
+                for pkg_name, pkg_record in installed.items():
+                    # treat pip-installed stuff as explicitly installed, too.
+                    if pkg_record.subdir == "pypi":
+                        log.debug("Update all: spec is pip-installed")
+                        new_specs_map[pkg_name] = MatchSpec(pkg_name)
+                    elif pkg_name not in new_specs_map:
+                        log.debug("Update all: adding spec to list because it was installed")
+                        new_specs_map[pkg_name] = MatchSpec(pkg_name)
+            else:
+                for pkg_name, pkg_record in installed.items():
+                    if pkg_name not in pinned:
+                        log.debug("Update all: spec is installed but not pinned")
+                        new_specs_map[pkg_name] = MatchSpec(pkg_name)
+                    else:
+                        log.debug("Update all: spec is installed and pinned")
+                        new_specs_map[pkg_name] = specs_map[pkg_name]
+            # We overwrite the specs map so far!
+            specs_map = new_specs_map
+
+        # Section 6 - Handle UPDATE_SPECS (note: this might be unimportant)
+        # Unfreezes the indirect specs that otherwise conflict
+        # with the update of the explicitly requested spec
+        elif update_modifier == UpdateModifier.UPDATE_SPECS:
+            from mamba.repoquery import search as mamba_search
+
+            potential_conflicts = []
+            for spec in self.specs_to_add:  # requested by the user
+                in_pins = spec.name not in pin_overrides and spec.name in pinned
+                in_history = spec.name in history
+                if in_pins or in_history:  # skip these
+                    continue
+                has_update = False
+                # Check if this spec has any available updates
+                installed_record = installed.get(spec.name)
+
+                if installed_record:
+                    # Check the index for available updates
+                    installed_version = VersionOrder(installed_record.version)
+                    query = mamba_search(f"{spec.name} >={installed_version}", pool=state["pool"])
+                    for pkg_record in query["result"]["pkgs"]:
+                        if pkg_record["channel"] == "installed":
+                            continue
+                        found_version = VersionOrder(pkg_record["version"])
+                        greater_version = found_version > installed_version
+                        greater_build = (
+                            found_version == installed_version
+                            and pkg_record["build_number"] > installed_record.build_number
+                        )
+                        if greater_version or greater_build:
+                            has_update = True
+                            break
+                if has_update:
+                    potential_conflicts.append(
+                        MatchSpec(
+                            spec.name,
+                            version=pkg_record["version"],
+                            build_number=pkg_record["build_number"],
+                        )
+                    )
+                else:
+                    potential_conflicts.append(spec)
+
+            # TODO: What shall we do with `potential_conflicts`??
+
+            log.debug("Relax constrains because it caused a conflict")
+            for pkg in conflicting.values():
+                # neuter the spec due to a conflict
+                if pkg.name in specs_map and pkg.name not in pinned:
+                    specs_map[pkg.name] = history.get(pkg.name, MatchSpec(pkg.name))
+
+        # Section 7 - Pin Python
+        log.debug("Adjust python pinning")
+        py_requested_explicitly = any(s.name == "python" for s in self.specs_to_add)
+        installed_python = installed.get("python")
+        if installed_python and not py_requested_explicitly:
+            freeze_installed = update_modifier == UpdateModifier.FREEZE_INSTALLED
+            if "python" not in conflicting and freeze_installed:
+                specs_map["python"] = installed_python.to_match_spec()
+            else:
+                # will our prefix record conflict with any explict spec?  If so, don't add
+                #     anything here - let python float when it hasn't been explicitly specified
+                python_spec = specs_map.get("python", MatchSpec("python"))
+                if not python_spec.get("version"):
+                    pinned_version = get_major_minor_version(installed_python.version) + ".*"
+                    python_spec = MatchSpec(python_spec, version=pinned_version)
+                specs_map["python"] = python_spec
+
+        # Section 8 - Make sure aggressive updates are not constrained now
+        if not context.offline:
+            log.debug("Make sure aggressive updates did not end up pinned again")
+            specs_map.update(
+                {s.name: s for s in context.aggressive_update_packages if s.name in specs_map}
+            )
+
+        # Section 9 - FINALLY we add the explicitly requested specs
+        log.debug("Add user specs")
+        specs_map.update({s.name: s for s in self.specs_to_add if s.name not in pin_overrides})
+
+        # Section 10 - Make sure `conda` is not downgraded
+        if "conda" in specs_map and paths_equal(self.prefix, context.conda_prefix):
+            conda_prefix_rec = state["conda_prefix_data"].get("conda")
+            if conda_prefix_rec:
+                version_req = f">={conda_prefix_rec.version}"
+                conda_requested_explicitly = any(s.name == "conda" for s in self.specs_to_add)
+                conda_spec = specs_map["conda"]
+                conda_in_specs_to_add_version = specs_map.get("conda", {}).get("version")
+                if not conda_in_specs_to_add_version:
+                    conda_spec = MatchSpec(conda_spec, version=version_req)
+                if context.auto_update_conda and not conda_requested_explicitly:
+                    conda_spec = MatchSpec("conda", version=version_req, target=None)
+                log.debug("Adjust conda spec")
+                specs_map["conda"] = conda_spec
+
+        # Section 11 - Mamba/Conda behaviour difference workaround
+        # If a spec is installed and has been requested with no constrains,
+        # we assume the user wants an update, so we add >{current_version}, but only if no
+        # flags have been passed -- otherwise interactions between implicit updates create unneeded
+        # conflicts
+        log.debug("Make sure specs are upgraded if requested explicitly and not in conflict")
+        if (
+            deps_modifier != DepsModifier.ONLY_DEPS
+            and update_modifier
+            not in (UpdateModifier.UPDATE_DEPS, UpdateModifier.FREEZE_INSTALLED)
+            and self._command in ("update", "", None, NULL)
+        ):
+            for spec in self.specs_to_add:
+                if (
+                    spec.name in specs_map
+                    and specs_map[spec.name].strictness == 1
+                    and spec.name in installed
+                ):
+                    conflicting_spec = conflicting.get(spec.name)
+                    if conflicting_spec and getattr(conflicting_spec, "missing", False):
+                        # We obtained a "nothing provides" error, which means this
+                        # spec cannot be updated further; no forced update then
+                        # TODO: Refactor conflict into dict of dicts with name->spec,reason
+                        continue
+                    if spec.name in ("pip", "setuptools"):
+                        # If added with no constrains, excluding their installed version can
+                        # result in unneded python downgrades
+                        # see tests/conda_env/test_cli.py::test_update_env_no_action_json_output
+                        continue
+                    installed_version = installed[spec.name].version
+                    if installed_version:
+                        # TODO: We might want to say "any version or build of this package",
+                        # but not the installed one
+                        specs_map[spec.name] = MatchSpec(
+                            name=spec.name, version=f"!={installed_version}"
+                        )
+
+        return specs_map
+
+    def _neuter_conflicts(self, state, ignore_pinned=False):
+        conflicting_specs = state["conflicting"].values()
+        specs_map = state["specs_map"]
+
+        # Are all conflicting specs in specs_map? If not, that means they're in
+        # track_features_specs or pinned_specs, which we should raise an error on.
+        # JRG: This won't probably work because Mamba reports conflicts one at a time...
+        specs_set = set(specs_map.values())
+        grouped_specs = groupby(lambda s: s in specs_set, conflicting_specs)
+        # force optional to true. This is what it is originally in
+        # pinned_specs, but we override that in _compute_specs_map to make it
+        # non-optional when there's a name match in the explicit package pool
+        conflicting_pinned_specs = groupby(
+            lambda s: MatchSpec(s, optional=True) in self._pinned_specs(state, ignore_pinned),
+            conflicting_specs,
+        )
+
+        if conflicting_pinned_specs.get(True):
+            in_specs_map = grouped_specs.get(True, ())
+            pinned_conflicts = conflicting_pinned_specs.get(True, ())
+            requested = (set(in_specs_map) | set(self.specs_to_add)) - set(pinned_conflicts)
+
+            raise SpecsConfigurationConflictError(
+                sorted(s.__str__() for s in requested),
+                sorted(s.__str__() for s in {s for s in pinned_conflicts}),
+                self.prefix,
+            )
+
+        log.debug("Neutering specs...")
+        for spec in conflicting_specs:
+            # if spec.name == "python":
+            #     continue
+            if spec.target and not spec.optional:
+                if spec.get("version"):
+                    neutered_spec = MatchSpec(spec.name, version=spec.version)
+                else:
+                    neutered_spec = MatchSpec(spec.name)
+                specs_map[spec.name] = neutered_spec
+            if spec.name not in specs_map:
+                # side-effect conflict; add to specs with less restrains
+                specs_map[spec.name] = MatchSpec(name=spec.name, target=spec.dist_str())
+
+        return specs_map
+
+    def _specs_map_to_tasks(self, state, specs_map):
+        import libmambapy as api
+
+        tasks = defaultdict(list)
+        history = state["history"].get_requested_specs_map()
+        specs_map = specs_map.copy()
+        installed = {rec.name: rec for rec in state["conda_prefix_data"].iter_records()}
+
+        # Section 11 - deprioritize installed stuff that wasn't requested
+        # These packages might not be available in future Python versions, but we don't
+        # want them to block a requested Python update
+        log.debug("Deprioritizing conflicts:")
+        protect_these = set(s.name for s in self.specs_to_add)  # explicitly requested
+        protect_these.update(("python", "conda"))
+        protect_these.update(
+            [pkg_name for pkg_name, pkg_record in installed.items() if pkg_record.is_unmanageable]
+        )
+        for conflict in state["conflicting"]:
+            if conflict in specs_map and conflict not in protect_these:
+                spec = specs_map.pop(conflict)
+                log.debug("  MOV: %s from specs_map to SOLVER_DISFAVOR", conflict)
+                spec_str = spec.conda_build_form()
+                tasks[("api.SOLVER_DISFAVOR", api.SOLVER_DISFAVOR)].append(spec_str)
+                tasks[("api.SOLVER_ALLOWUNINSTALL", api.SOLVER_ALLOWUNINSTALL)].append(spec_str)
+
+        # Wrap up and create tasks for the solver
+        for name, spec in specs_map.items():
+            if name.startswith("__"):
+                continue
+            if name in installed:
+                if name == "python":
+                    key = (
+                        "api.SOLVER_UPDATE | api.SOLVER_ESSENTIAL",
+                        api.SOLVER_UPDATE | api.SOLVER_ESSENTIAL,
+                    )
+                else:
+                    key = "api.SOLVER_UPDATE", api.SOLVER_UPDATE
+
+                history_spec = history.get(name)
+                if history_spec:
+                    installed_rec = installed[name]
+                    ms = MatchSpec(
+                        name=installed_rec.name,
+                        version=installed_rec.version,
+                        build=installed_rec.build,
+                    )
+                    tasks[("api.SOLVER_USERINSTALLED", api.SOLVER_USERINSTALLED)].append(
+                        ms.conda_build_form()
+                    )
+            else:
+                key = "api.SOLVER_INSTALL", api.SOLVER_INSTALL
+            tasks[key].append(spec.conda_build_form())
+
+        return tasks
+
+    def _pinned_specs(self, state, ignore_pinned=False):
+        if ignore_pinned:
+            return ()
+        pinned_specs = get_pinned_specs(self.prefix)
+        pin_these_specs = []
+        for pin in pinned_specs:
+            installed_pins = state["conda_prefix_data"].query(pin.name) or ()
+            for installed in installed_pins:
+                if not pin.match(installed):
+                    raise SpecsConfigurationConflictError([installed], [pin], self.prefix)
+            pin_these_specs.append(pin)
+        return tuple(pin_these_specs)
+
+    def _history_specs(self):
+        return [
+            s.conda_build_form() for s in History(self.prefix).get_requested_specs_map().values()
+        ]
+
+    def _run_solver(self, state):
+        solver = state["solver"]
+        solved = solver.solve()
+        if solved:
+            # Clear potential conflicts we used to have
+            state["conflicting"].clear()
+        else:
+            # Report problems if any
+            # it would be better if we could pass a graph object or something
+            # that the exception can actually format if needed
+            problems = solver.problems_to_str()
+            state["conflicting"] = self._parse_problems(problems, state["conflicting"].copy())
+            log.debug("Attempt failed with %s", problems)
+
+        return solved
+
+    def _export_final_state(self, state):
+        import libmambapy as api
+        from .libmamba_utils import to_package_record_from_subjson
+
+        solver = state["solver"]
+        index = state["index"]
+        installed_pkgs = state["installed_pkgs"]
+
+        transaction = api.Transaction(
+            solver,
+            api.MultiPackageCache(context.pkgs_dirs),
+        )
+        (names_to_add, names_to_remove), to_link, to_unlink = transaction.to_conda()
+
+        # What follows below is taken from mamba.utils.to_txn with some patches
+        conda_prefix_data = PrefixData(self.prefix)
+        final_precs = IndexedSet(conda_prefix_data.iter_records())
+
+        lookup_dict = {}
+        for _, entry in index:
+            lookup_dict[
+                entry["channel"].platform_url(entry["platform"], with_credentials=False)
+            ] = entry
+
+        for _, pkg in to_unlink:
+            for i_rec in installed_pkgs:
+                # Do not try to unlink virtual pkgs, virtual eggs, etc
+                if not i_rec.is_unmanageable and i_rec.fn == pkg:
+                    final_precs.remove(i_rec)
+                    break
+            else:
+                log.warn("Tried to unlink %s but it is not installed or manageable?", pkg)
+
+        for c, pkg, jsn_s in to_link:
+            if c.startswith("file://"):
+                # The conda functions (specifically remove_auth) assume the input
+                # is a url; a file uri on windows with a drive letter messes them up.
+                key = c
+            else:
+                key = split_anaconda_token(remove_auth(c))[0]
+            if key not in lookup_dict:
+                raise ValueError("missing key {} in channels: {}".format(key, lookup_dict))
+            sdir = lookup_dict[key]
+            rec = to_package_record_from_subjson(sdir, pkg, jsn_s)
+            final_precs.add(rec)
+
+        # state["old_specs_to_add"] = self.specs_to_add
+        # state["old_specs_to_remove"] = self.specs_to_remove
+        state["final_prefix_state"] = final_precs
+        state["names_to_add"] = [name for name in names_to_add if not name.startswith("__")]
+        state["names_to_remove"] = [name for name in names_to_remove if not name.startswith("__")]
+
+        return state
+
+    def _parse_problems(self, problems, previous):
+        dashed_specs = []  # e.g. package-1.2.3-h5487548_0
+        conda_build_specs = []  # e.g. package 1.2.8.*
+        missing = []
+        for line in problems.splitlines():
+            line = line.strip()
+            words = line.split()
+            if not line.startswith("- "):
+                continue
+            if "none of the providers can be installed" in line:
+                assert words[1] == "package"
+                assert words[3] == "requires"
+                dashed_specs.append(words[2])
+                end = words.index("but")
+                conda_build_specs.append(words[4:end])
+            elif "- nothing provides" in line and "needed by" in line:
+                missing.append(words[-1])
+                dashed_specs.append(words[-1])
+            elif "- nothing provides" in line:
+                missing.append(words[4:])
+                conda_build_specs.append(words[4:])
+
+        conflicts = {}
+        for conflict in dashed_specs:
+            name, version, build = conflict.rsplit("-", 2)
+            conflicts[name] = MatchSpec(name=name, version=version, build=build)
+            conflicts[name].missing = conflict in missing
+        for conflict in conda_build_specs:
+            kwargs = {"name": conflict[0].rstrip(",")}
+            if len(conflict) >= 2:
+                kwargs["version"] = conflict[1].rstrip(",")
+            if len(conflict) == 3:
+                kwargs["build"] = conflict[2].rstrip(",")
+            conflicts[kwargs["name"]] = MatchSpec(**kwargs)
+            conflicts[kwargs["name"]].missing = conflict in missing
+
+        previous_set = set(previous.values())
+        current_set = set(conflicts.values())
+
+        diff = current_set.difference(previous_set)
+        if len(diff) > 1 and "python" in conflicts:
+            # Only report python as conflict if it's the only conflict reported
+            # This helps us prioritize neutering for other dependencies first
+            conflicts.pop("python")
+
+        current_set = set(conflicts.values())
+        if (previous and (previous_set == current_set)) or len(diff) >= 10:
+            # We have same or more (up to 10) conflicts now! Abort to avoid recursion.
+            self.raise_for_problems(problems)
+
+        # Preserve old conflicts (now neutered as name-only spes) in the
+        # new list of conflicts (unless a different variant is now present)
+        # This allows us to have a conflict memory for next attempts.
+        for name, spec in previous.items():
+            if name not in conflicts:
+                conflicts[name] = spec
+        return conflicts
+
+    def _post_solve_tasks(
+        self,
+        state,
+        deps_modifier=NULL,
+        update_modifier=NULL,
+        force_reinstall=NULL,
+        ignore_pinned=NULL,
+        force_remove=NULL,
+        prune=NULL,
+    ):
+        specs_map = state["specs_map"]
+        final_prefix_map = TrackedDict({pkg.name: pkg for pkg in state["final_prefix_state"]})
+        history_map = state["history"].get_requested_specs_map()
+        self.neutered_specs = tuple(
+            pkg_spec
+            for pkg_name, pkg_spec in specs_map.items()
+            if pkg_name in history_map and pkg_spec.strictness < history_map[pkg_name].strictness
+        )
+
+        # TODO: We are currently not handling dependencies orphaned after identifying
+        # conflicts (stored in `ssc.add_back_map`).
+
+        if deps_modifier == DepsModifier.NO_DEPS:
+            # In the NO_DEPS case, we need to start with the original list of packages in the
+            # environment, and then only modify packages that match specs_to_add or
+            # specs_to_remove.
+            #
+            # Help information notes that use of NO_DEPS is expected to lead to broken
+            # environments.
+            _no_deps_solution = IndexedSet(state["conda_prefix_data"].iter_records())
+            only_remove_these = set(
+                prec
+                for name in state["names_to_remove"]
+                for prec in _no_deps_solution
+                if MatchSpec(name).match(prec)
+            )
+            _no_deps_solution -= only_remove_these
+
+            only_add_these = set(
+                prec
+                for name in state["names_to_add"]
+                for prec in state["final_prefix_state"]
+                if MatchSpec(name).match(prec)
+            )
+            remove_before_adding_back = set(prec.name for prec in only_add_these)
+            _no_deps_solution = IndexedSet(
+                prec for prec in _no_deps_solution if prec.name not in remove_before_adding_back
+            )
+            _no_deps_solution |= only_add_these
+            final_prefix_map = {p.name: p for p in _no_deps_solution}
+
+        # If ONLY_DEPS is set, we need to make sure the originally requested specs
+        # are not part of the result
+        elif (
+            deps_modifier == DepsModifier.ONLY_DEPS
+            and update_modifier != UpdateModifier.UPDATE_DEPS
+        ):
+            graph = PrefixGraph(state["final_prefix_state"], self.specs_to_add)
+            removed_nodes = graph.remove_youngest_descendant_nodes_with_specs()
+            specs_to_add = set(MatchSpec(name) for name in state["names_to_add"])
+            for pkg_record in removed_nodes:
+                for dependency in pkg_record.depends:
+                    dependency = MatchSpec(dependency)
+                    if dependency.name not in specs_map:
+                        specs_to_add.add(dependency)
+            state["names_to_add"] = set(spec.name for spec in specs_to_add)
+
+            # Add back packages that are already in the prefix.
+            specs_to_remove_names = set(name for name in state["names_to_remove"])
+            add_back = [
+                state["conda_prefix_data"].get(node.name, None)
+                for node in removed_nodes
+                if node.name not in specs_to_remove_names
+            ]
+            final_prefix_map = {p.name: p for p in concatv(graph.graph, filter(None, add_back))}
+
+        elif update_modifier == UpdateModifier.UPDATE_DEPS:
+            # This code below is adapted from the classic solver logic
+            # found in Solver._post_sat_handling()
+
+            # We need a post-solve to find the full chain of dependencies
+            # for the requested specs (1) The previous solve gave us
+            # the packages that would be installed normally. We take
+            # that list and process their dependencies too so we can add
+            # those explicitly to the list of packages to be updated.
+            # If additionally DEPS_ONLY is set, we need to remove the
+            # originally requested specs from the final list of explicit
+            # packages.
+
+            # (2) Get the dependency tree for each dependency
+            graph = PrefixGraph(state["final_prefix_state"])
+            update_names = set()
+            for spec in self.specs_to_add:
+                node = graph.get_node_by_name(spec.name)
+                update_names.update(ancest_rec.name for ancest_rec in graph.all_ancestors(node))
+            specs_map = TrackedDict({name: MatchSpec(name) for name in update_names})
+
+            # Remove pinned_specs and any python spec (due to major-minor pinning business rule).
+            for spec in self._pinned_specs(state, ignore_pinned):
+                specs_map.pop(spec.name, None)
+            # TODO: This kind of version constrain patching is done several times in different
+            # parts of the code, so it might be a good candidate for a dedicate utility function
+            if "python" in specs_map:
+                python_rec = state["conda_prefix_data"].get("python")
+                py_ver = ".".join(python_rec.version.split(".")[:2]) + ".*"
+                specs_map["python"] = MatchSpec(name="python", version=py_ver)
+
+            # Add in the original specs_to_add on top.
+            specs_map.update({spec.name: spec for spec in self.specs_to_add})
+
+            with context.override("quiet", True):
+                # Create a new solver instance to perform a 2nd solve with deps added
+                # We do it like this to avoid overwriting state accidentally. Instead,
+                # we will import the needed state bits manually.
+                solver2 = self.__class__(
+                    self.prefix,
+                    self.channels,
+                    self.subdirs,
+                    list(specs_map.values()),
+                    self.specs_to_remove,
+                    self._repodata_fn,
+                    "recursive_call_for_update_deps",
+                )
+                solved_pkgs = solver2.solve_final_state(
+                    update_modifier=UpdateModifier.UPDATE_SPECS,  # avoid recursion!
+                    deps_modifier=deps_modifier,
+                    ignore_pinned=ignore_pinned,
+                    force_remove=force_remove,
+                    force_reinstall=force_reinstall,
+                    prune=prune,
+                )
+                final_prefix_map = {p.name: p for p in solved_pkgs}
+                # NOTE: We are exporting state back to the class! These are expected by
+                # super().solve_for_diff() and super().solve_for_transaction() :/
+                self.specs_to_add = solver2.specs_to_add.copy()
+                self.specs_to_remove = solver2.specs_to_remove.copy()
+
+            prune = False
+
+        # Prune leftovers
+        if prune:
+            graph = PrefixGraph(final_prefix_map.values(), specs_map.values())
+            graph.prune()
+            final_prefix_map = {p.name: p for p in graph.graph}
+
+        # TODO: Review performance here just in case
+        return IndexedSet(PrefixGraph(final_prefix_map.values()).graph)
+
+    def raise_for_problems(self, problems):
+        for line in problems.splitlines():
+            line = line.strip()
+            if line.startswith("- nothing provides requested"):
+                packages = line.split()[4:]
+                raise PackagesNotFoundError([" ".join(packages)])
+        raise RawStrUnsatisfiableError(problems)
+
+
+class TrackedDict(dict):
+    def __setitem__(self, k, v) -> None:
+        if k in self:
+            oldv = self[k]
+            if v == oldv:
+                log.debug("  EQU: %s = %s", k, v)
+            else:
+                log.debug("  UPD: %s from %s to %s", k, self[k], v)
+        else:
+            log.debug("  NEW: %s = %s", k, v)
+        return super().__setitem__(k, v)
+
+    def __delitem__(self, v) -> None:
+        log.debug("  DEL: %s", v)
+        return super().__delitem__(v)
+
+    def update(self, *args, **kwargs):
+        old = self.copy()
+        super().update(*args, **kwargs)
+        for k, v in self.items():
+            if k in old:
+                oldv = old[k]
+                if v != oldv:
+                    log.debug("  UPD: %s from %s to %s", k, old[k], v)
+            else:
+                log.debug("  NEW: %s = %s", k, v)

--- a/conda_libmamba_solver/libmamba2.py
+++ b/conda_libmamba_solver/libmamba2.py
@@ -1,0 +1,622 @@
+import os
+from itertools import chain
+from collections import defaultdict, OrderedDict
+import logging
+import sys
+from tempfile import NamedTemporaryFile
+from typing import Iterable, Mapping, Optional, Union
+from textwrap import dedent
+
+from conda import __version__ as _conda_version
+from conda.base.constants import REPODATA_FN, ChannelPriority, DepsModifier, UpdateModifier
+from conda.base.context import context
+from conda.common.constants import NULL
+from conda.common.io import CapturedDescriptor
+from conda.common.serialize import json_dump, json_load
+from conda.common.url import (
+    escape_channel_url,
+    split_anaconda_token,
+    remove_auth,
+)
+from conda.exceptions import (
+    PackagesNotFoundError,
+    RawStrUnsatisfiableError,
+    SpecsConfigurationConflictError,
+    UnsatisfiableError,
+)
+from conda.models.channel import Channel
+from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
+from conda.core.solve import Solver
+
+from .state import SolverInputState, SolverOutputState, IndexHelper
+
+log = logging.getLogger(__name__)
+
+
+class LibMambaIndexHelper(IndexHelper):
+    def __init__(
+        self,
+        installed_records: Iterable[PackageRecord] = (),
+        channels: Iterable[Union[Channel, str]] = None,
+        subdirs: Iterable[str] = None,
+    ):
+        import libmambapy as api
+        from .libmamba_utils import load_channels
+
+        self._pool = api.Pool()
+
+        # export installed records to a temporary json file
+        exported_installed = {"packages": {}}
+        for record in installed_records:
+            exported_installed["packages"][record.fn] = {
+                **record.dist_fields_dump(),
+                "depends": record.depends,
+                "constrains": record.constrains,
+                "build": record.build,
+            }
+        with NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            f.write(json_dump(exported_installed))
+        installed = api.Repo(self._pool, "installed", f.name, "")
+        installed.set_installed()
+        os.unlink(f.name)
+
+        if channels is None:
+            channels = context.channels
+        if subdirs is None:
+            subdirs = context.subdirs
+
+        self._index = load_channels(
+            pool=self._pool,
+            channels=self._channel_urls(channels),
+            repos=[installed],
+            prepend=False,
+            use_local=context.use_local,
+            platform=subdirs,
+        )
+
+        self._query = api.Query(self._pool)
+        self._format = api.QueryFormat.JSON
+
+    @staticmethod
+    def _channel_urls(channels: Iterable[Union[Channel, str]]):
+        """
+        TODO: libmambapy could handle path to url, and escaping
+        but so far we are doing it ourselves
+        """
+
+        def _channel_to_url_or_name(channel):
+            # This fixes test_activate_deactivate_modify_path_bash
+            # and other local channels (path to url) issues
+            urls = []
+            for url in channel.urls():
+                url = url.rstrip("/").rsplit("/", 1)[0]  # remove subdir
+                urls.append(escape_channel_url(url))
+            # deduplicate
+            urls = list(OrderedDict.fromkeys(urls))
+            return urls
+
+        channels = [url for c in channels for url in _channel_to_url_or_name(Channel(c))]
+        if context.restore_free_channel and "https://repo.anaconda.com/pkgs/free" not in channels:
+            channels.append("https://repo.anaconda.com/pkgs/free")
+
+        return tuple(channels)
+
+    def whoneeds(self, query: str):
+        return self._query.whoneeds(query, self._format)
+
+    def depends(self, query: str):
+        return self._query.depends(query, self._format)
+
+    def search(self, query: str):
+        return self._query.find(query, self._format)
+
+    def explicit_pool(self, specs: Iterable[MatchSpec]) -> Iterable[str]:
+        """
+        Returns all the package names that (might) depend on the passed specs
+        """
+        explicit_pool = set()
+        for spec in specs:
+            result_str = self.depends(spec.dist_str())
+            result = json_load(result_str)
+            for pkg in result["result"]["pkgs"]:
+                explicit_pool.add(pkg["name"])
+        return tuple(explicit_pool)
+
+
+class LibMambaSolver2(Solver):
+    """
+    Cleaner implementation using the ``state`` module helpers.
+    """
+
+    _uses_ssc = False
+
+    def __init__(
+        self,
+        prefix,
+        channels,
+        subdirs=(),
+        specs_to_add=(),
+        specs_to_remove=(),
+        repodata_fn=REPODATA_FN,
+        command=NULL,
+    ):
+        if specs_to_add and specs_to_remove:
+            raise ValueError(
+                "Only one of `specs_to_add` and `specs_to_remove` can be set at a time"
+            )
+        if specs_to_remove and command is NULL:
+            command = "remove"
+
+        super().__init__(
+            prefix,
+            channels,
+            subdirs=subdirs,
+            specs_to_add=specs_to_add,
+            specs_to_remove=specs_to_remove,
+            repodata_fn=repodata_fn,
+            command=command,
+        )
+
+        if self.subdirs is NULL or not self.subdirs:
+            self.subdirs = context.subdirs
+
+        # These three attributes are set during ._setup_solver()
+        self.solver = None
+        self._solver_options = None
+
+    def solve_final_state(
+        self,
+        update_modifier=NULL,
+        deps_modifier=NULL,
+        prune=NULL,
+        ignore_pinned=NULL,
+        force_remove=NULL,
+        should_retry_solve=False,
+    ):
+        # Temporary, only during experimental phase to ease debugging
+        self._print_info()
+
+        in_state = SolverInputState(
+            prefix=self.prefix,
+            requested=self.specs_to_add or self.specs_to_remove,
+            update_modifier=update_modifier,
+            deps_modifier=deps_modifier,
+            prune=prune,
+            ignore_pinned=ignore_pinned,
+            force_remove=force_remove,
+            command=self._command,
+        )
+
+        out_state = SolverOutputState(solver_input_state=in_state)
+
+        # These tasks do _not_ require a solver...
+        # TODO: Abstract away in the base class?
+        none_or_final_state = out_state.early_exit()
+        if none_or_final_state is not None:
+            return none_or_final_state
+
+        # From now on we _do_ require a solver and the index
+        from .libmamba_utils import init_api_context
+
+        with CapturedDescriptor(stream=sys.stderr, threaded=True) as captured:
+            api_ctx = init_api_context(verbosity=3)
+            index = LibMambaIndexHelper(
+                installed_records=chain(in_state.installed.values(), in_state.virtual.values()),
+                channels=self._channels,
+                subdirs=self.subdirs,
+            )
+        if captured.text:
+            log.debug("LibMambaIndexHelper:\n%s", captured.text)
+        self._setup_solver(index)
+
+        for attempt in range(1, max(1, len(in_state.installed)) + 1):
+            log.debug("Starting solver attempt %s", attempt)
+            if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
+                print("----- Starting solver attempt", attempt, "------", file=sys.stderr)
+            try:
+                solved = self._solve_attempt(in_state, out_state, index)
+                if solved:
+                    break
+            except (UnsatisfiableError, PackagesNotFoundError):
+                solved = False
+                break  # try with last attempt
+            else:  # didn't solve yet, but can retry
+                out_state = SolverOutputState(
+                    solver_input_state=in_state,
+                    specs=dict(out_state.specs),
+                    records=dict(out_state.records),
+                    for_history=dict(out_state.for_history),
+                    neutered=dict(out_state.neutered),
+                    conflicts=dict(out_state.conflicts),
+                )
+        if not solved:
+            log.debug("Last attempt: reporting all installed as conflicts")
+            if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
+                print("------ Last attempt! ------", file=sys.stderr)
+            out_state.conflicts.update(
+                {
+                    name: record.to_match_spec()
+                    for name, record in in_state.installed.items()
+                    # TODO: These conditions might not be needed here
+                    if not record.is_unmanageable
+                    # or name not in in_state.history
+                    # or name not in in_state.requested
+                    # or name not in in_state.pinned
+                },
+                reason="Last attempt: all installed packages exposed "
+                "as conflicts for maximum flexibility",
+            )
+            # we only check this for "desperate" strategies in _specs_to_tasks
+            self._command = "last_solve_attempt"
+            solved = self._solve_attempt(in_state, out_state, index)
+            if not solved:
+                # If we haven't found a solution already, we failed...
+                self._raise_for_problems()
+
+        # We didn't fail? Nice, let's return the calculated state
+        self._export_solved_records(in_state, out_state, index)
+
+        # Run post-solve tasks
+        out_state.post_solve(solver=self)
+        if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
+            print("SOLUTION for command", self._command, ":", file=sys.stderr)
+            for name, record in out_state.records.items():
+                print(
+                    " ",
+                    record.to_match_spec().conda_build_form(),
+                    "# reasons=",
+                    out_state.records._reasons.get(name, "<None>"),
+                    file=sys.stderr,
+                )
+
+        self.neutered_specs = tuple(out_state.neutered.values())
+
+        # Restore intended verbosity to avoid unwanted
+        # "freeing xxxx..." messages when the libmambpy objects are deleted
+        api_ctx.verbosity = context.verbosity
+        api_ctx.set_verbosity(context.verbosity)
+
+        return out_state.current_solution
+
+    def _print_info(self):
+        if not context.json and not context.quiet:
+            print(
+                dedent(
+                    f"""
+                    ----       USING EXPERIMENTAL LIBMAMBA2 INTEGRATIONS       ----
+                        This is a highly experimental product. If something is
+                        not working as expected, please submit an issue at
+                        https://github.com/conda/conda and attach the log file
+                        found in the following path. Thank you!
+
+                        {context.logfile_path}
+
+                    ---------------------------------------------------------------
+                    """
+                )
+            )
+
+        import mamba
+
+        log.info("Using experimental libmamba2 integrations")
+        log.info("Conda version: %s", _conda_version)
+        log.info("Mamba version: %s", mamba.__version__)
+        log.info("Target prefix: %s", self.prefix)
+        log.info("Command: %s", sys.argv)
+        log.info("Specs to add: %s", self.specs_to_add)
+        log.info("Specs to remove: %s", self.specs_to_remove)
+
+    def _setup_solver(self, index: LibMambaIndexHelper):
+        import libmambapy as api
+
+        self._solver_options = solver_options = [
+            (api.SOLVER_FLAG_ALLOW_DOWNGRADE, 1),
+            (api.SOLVER_FLAG_ALLOW_UNINSTALL, 1),
+            (api.SOLVER_FLAG_INSTALL_ALSO_UPDATES, 1),
+            (api.SOLVER_FLAG_FOCUS_BEST, 1),
+            (api.SOLVER_FLAG_BEST_OBEY_POLICY, 1),
+        ]
+        if context.channel_priority is ChannelPriority.STRICT:
+            solver_options.append((api.SOLVER_FLAG_STRICT_REPO_PRIORITY, 1))
+
+        with CapturedDescriptor(stream=sys.stderr, threaded=True) as captured:
+            self.solver = api.Solver(index._pool, self._solver_options)
+        if captured.text:
+            log.debug("Solver initialization:\n%s", captured.text)
+
+    def _solve_attempt(
+        self,
+        in_state: SolverInputState,
+        out_state: SolverOutputState,
+        index: LibMambaIndexHelper,
+    ):
+        self._setup_solver(index)
+
+        log.debug("New solver attempt")
+        log.debug("Current conflicts (including learnt ones): %s", out_state.conflicts)
+        if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
+            print(
+                "Current conflicts (including learnt ones):", out_state.conflicts, file=sys.stderr
+            )
+
+        # ## First, we need to obtain the list of specs ###
+        try:
+            out_state.prepare_specs(index)
+        except SpecsConfigurationConflictError as exc:
+            # in the last attempt we have marked everything
+            # as a conflict so everything gets unconstrained
+            # however this will be detected as a conflict with the
+            # pins, but we can ignore it because we did it ourselves
+            if self._command != "last_solve_attempt":
+                raise exc
+
+        log.debug("Computed specs: %s", out_state.specs)
+        if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
+            print("Computed specs:", out_state.specs, file=sys.stderr)
+
+        # ## Convert to tasks
+        tasks = self._specs_to_tasks(in_state, out_state)
+        tasks_list_as_str = "\n".join(
+            [f"  {task_str}: {', '.join(specs)}" for (task_str, _), specs in tasks.items()]
+        )
+        if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
+            print("Created %s tasks:\n%s" % (len(tasks), tasks_list_as_str), file=sys.stderr)
+        for (task_name, task_type), specs in tasks.items():
+            log.debug("Adding task %s with specs %s", task_name, specs)
+            with CapturedDescriptor(stream=sys.stderr, threaded=True) as captured:
+                self.solver.add_jobs(specs, task_type)
+            if captured.text:
+                log.debug("Solver.solve:\n%s", captured.text)
+
+        # ## Run solver
+        with CapturedDescriptor(stream=sys.stderr, threaded=True) as captured:
+            solved = self.solver.solve()
+        if captured.text:
+            log.debug("Solver.solve:\n%s", captured.text)
+
+        if solved:
+            out_state.conflicts.clear(reason="Solution found")
+            return solved
+
+        problems = self.solver.problems_to_str()
+        old_conflicts = out_state.conflicts.copy()
+        new_conflicts = self._problems_to_specs(problems, old_conflicts)
+        log.debug("Attempt failed with %s conflicts", len(new_conflicts))
+        out_state.conflicts.update(new_conflicts.items(), reason="New conflict found")
+        return False
+
+    def _specs_to_tasks(self, in_state: SolverInputState, out_state: SolverOutputState):
+        log.debug("Creating tasks for %s specs", len(out_state.specs))
+        if in_state.is_removing:
+            return self._specs_to_tasks_remove(in_state, out_state)
+        return self._specs_to_tasks_add(in_state, out_state)
+
+    def _specs_to_tasks_add(self, in_state: SolverInputState, out_state: SolverOutputState):
+        import libmambapy as api
+
+        # These packages receive special protection, since they will be
+        # exempt from conflict treatment (ALLOWUNINSTALL) and if installed
+        # their updates will be considered ESSENTIAL and USERINSTALLED
+        protected = (
+            ["python", "conda"]
+            + list(in_state.history.keys())
+            + list(in_state.aggressive_updates.keys())
+        )
+        tasks = defaultdict(list)
+        for name, spec in out_state.specs.items():
+            spec_str = spec.conda_build_form()
+            if name.startswith("__"):
+                continue
+            key = "INSTALL", api.SOLVER_INSTALL
+            # ## Low-prio task ###
+            if name in out_state.conflicts and name not in protected:
+                tasks[("DISFAVOR", api.SOLVER_DISFAVOR)].append(spec_str)
+                tasks[("ALLOWUNINSTALL", api.SOLVER_ALLOWUNINSTALL)].append(spec_str)
+            if name in in_state.installed:
+                installed = in_state.installed[name]
+                # ## Regular task ###
+                key = "UPDATE", api.SOLVER_UPDATE
+                # ## Protect if installed AND history
+                if name in protected:
+                    installed_spec = installed.to_match_spec().conda_build_form()
+                    tasks[("USERINSTALLED", api.SOLVER_USERINSTALLED)].append(installed_spec)
+                    # This is "just" an essential job, so it gets higher priority in the solver
+                    # conflict resolution. We do this because these are "protected" packages
+                    # (history, aggressive updates) that we should try not messing with if
+                    # conflicts appear
+                    key = ("UPDATE | ESSENTIAL", api.SOLVER_UPDATE | api.SOLVER_ESSENTIAL)
+
+                # ## Here we deal with the "bare spec update" problem
+                # ## I am only adding this for legacy / test compliancy reasons; forced updates
+                # ## like this should (imo) use constrained specs (e.g. conda install python=3)
+                # ## or the update command as in `conda update python`. however conda thinks
+                # ## differently of update vs install (quite counterintuitive):
+                # ##   https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/installing-with-conda.html#conda-update-versus-conda-install  # noqa
+                # ## this is tested in:
+                # ##   tests/core/test_solve.py::test_pinned_1
+                # ##   tests/test_create.py::IntegrationTests::test_update_with_pinned_packages
+                # ## fixing this changes the outcome in other tests!
+                # let's say we have an environment with python 2.6 and we say `conda install
+                # python` libsolv will say we already have python and there's no reason to do
+                # anything else even if we force an update with essential, other packages in the
+                # environment (built for py26) will keep it in place. we offer two ways to deal
+                # with this libsolv behaviour issue:
+                #   A) introduce an artificial version spec `python !=<currently installed>`
+                #   B) use FORCEBEST -- this would be ideal, but sometimes in gets in the way,
+                #      so we only use it as a last attempt effort.
+                # NOTE: This is a dirty-ish workaround... rethink?
+                requested = in_state.requested.get(name)
+                conditions = (
+                    requested,
+                    spec == requested,
+                    spec.strictness == 1,
+                    self._command in ("update", "last_solve_attempt", None, NULL),
+                    in_state.deps_modifier != DepsModifier.ONLY_DEPS,
+                    in_state.update_modifier
+                    not in (UpdateModifier.UPDATE_DEPS, UpdateModifier.FREEZE_INSTALLED),
+                )
+                if all(conditions):
+                    if self._command == "last_solve_attempt":
+                        key = (
+                            "UPDATE | ESSENTIAL | FORCEBEST",
+                            api.SOLVER_UPDATE | api.SOLVER_ESSENTIAL | api.SOLVER_FORCEBEST,
+                        )
+                    else:
+                        # NOTE: This is ugly and there should be another way
+                        spec_str = f"{name} !={installed.version}"
+
+            tasks[key].append(spec_str)
+
+        return tasks
+
+    def _specs_to_tasks_remove(self, in_state: SolverInputState, out_state: SolverOutputState):
+        # TODO: Consider merging add/remove in a single logic this so there's no split
+        import libmambapy as api
+
+        tasks = defaultdict(list)
+
+        # Protect history and aggressive updates from being uninstalled if possible
+        for name, record in out_state.records.items():
+            if name in in_state.history or name in in_state.aggressive_updates:
+                spec = record.to_match_spec().conda_build_form()
+                tasks[("USERINSTALLED", api.SOLVER_USERINSTALLED)].append(spec)
+
+        # No complications here: delete requested and their deps
+        # TODO: There are some flags to take care of here, namely:
+        # --all
+        # --no-deps
+        # --deps-only
+        key = ("ERASE | CLEANDEPS", api.SOLVER_ERASE | api.SOLVER_CLEANDEPS)
+        for name, spec in in_state.requested.items():
+            tasks[key].append(spec.conda_build_form())
+
+        return tasks
+
+    def _problems_to_specs(self, problems: str, previous: Mapping[str, MatchSpec]):
+        if self.solver is None:
+            raise RuntimeError("Solver is not initialized. Call `._setup_solver()` first.")
+
+        dashed_specs = []  # e.g. package-1.2.3-h5487548_0
+        conda_build_specs = []  # e.g. package 1.2.8.*
+        for line in problems.splitlines():
+            line = line.strip()
+            words = line.split()
+            if not line.startswith("- "):
+                continue
+            if "none of the providers can be installed" in line:
+                if words[1] != "package" or words[3] != "requires":
+                    raise ValueError(f"Unknown message: {line}")
+                dashed_specs.append(words[2])
+                end = words.index("but")
+                conda_build_specs.append(words[4:end])
+            elif "- nothing provides" in line and "needed by" in line:
+                dashed_specs.append(words[-1])
+            elif "- nothing provides" in line:
+                conda_build_specs.append(words[4:])
+
+        conflicts = {}
+        for conflict in dashed_specs:
+            name, version, build = conflict.rsplit("-", 2)
+            conflicts[name] = MatchSpec(name=name, version=version, build=build)
+        for conflict in conda_build_specs:
+            kwargs = {"name": conflict[0].rstrip(",")}
+            if len(conflict) >= 2:
+                kwargs["version"] = conflict[1].rstrip(",")
+            if len(conflict) == 3:
+                kwargs["build"] = conflict[2].rstrip(",")
+            conflicts[kwargs["name"]] = MatchSpec(**kwargs)
+
+        previous_set = set(previous.values())
+        current_set = set(conflicts.values())
+
+        diff = current_set.difference(previous_set)
+        if len(diff) > 1 and "python" in conflicts:
+            # Only report python as conflict if it's the only conflict reported
+            # This helps us prioritize neutering for other dependencies first
+            conflicts.pop("python")
+
+        current_set = set(conflicts.values())
+        if (previous and (previous_set == current_set)) or len(diff) >= 10:
+            # We have same or more (up to 10) conflicts now! Abort to avoid recursion.
+            self._raise_for_problems(problems)
+
+        return conflicts
+
+    def _raise_for_problems(self, problems: Optional[str] = None):
+        if self.solver is None:
+            raise RuntimeError("Solver is not initialized. Call `._setup_solver()` first.")
+
+        # TODO: merge this with parse_problems somehow
+        # e.g. return a dict of exception type -> specs involved
+        # and we raise it here
+        if problems is None:
+            problems = self.solver.problems_to_str()
+
+        for line in problems.splitlines():
+            line = line.strip()
+            if line.startswith("- nothing provides requested"):
+                packages = line.split()[4:]
+                raise PackagesNotFoundError([" ".join(packages)])
+        raise RawStrUnsatisfiableError(problems)
+
+    def _export_solved_records(
+        self,
+        in_state: SolverInputState,
+        out_state: SolverOutputState,
+        index: LibMambaIndexHelper,
+    ):
+        if self.solver is None:
+            raise RuntimeError("Solver is not initialized. Call `._setup_solver()` first.")
+
+        import libmambapy as api
+        from .libmamba_utils import to_package_record_from_subjson
+
+        with CapturedDescriptor(stream=sys.stderr, threaded=True) as captured:
+            transaction = api.Transaction(self.solver, api.MultiPackageCache(context.pkgs_dirs))
+            (names_to_add, names_to_remove), to_link, to_unlink = transaction.to_conda()
+        if captured.text:
+            log.debug("Solver.solve:\n%s", captured.text)
+
+        if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
+            print("TO_LINK", to_link, file=sys.stderr)
+            print("TO_UNLINK", to_unlink, file=sys.stderr)
+
+        channel_lookup = {}
+        for _, entry in index._index:
+            key = entry["channel"].platform_url(entry["platform"], with_credentials=False)
+            channel_lookup[key] = entry
+
+        for _, filename in to_unlink:
+            for name, record in in_state.installed.items():
+                if record.is_unmanageable:
+                    # ^ Do not try to unlink virtual pkgs, virtual eggs, etc
+                    continue
+                if record.fn == filename:  # match!
+                    out_state.records.pop(name, None, reason="Unlinked by solver")
+                    break
+            else:
+                log.warn("Tried to unlink %s but it is not installed or manageable?", filename)
+
+        for channel, filename, json_str in to_link:
+            if channel.startswith("file://"):
+                # The conda functions (specifically remove_auth) assume the input
+                # is a url; a file uri on windows with a drive letter messes them up.
+                key = channel
+            else:
+                key = split_anaconda_token(remove_auth(channel))[0]
+            if key not in channel_lookup:
+                raise ValueError(f"missing key {key} in channels {channel_lookup}")
+            record = to_package_record_from_subjson(channel_lookup[key], filename, json_str)
+            out_state.records.set(
+                record.name, record, reason="Part of solution calculated by libmamba"
+            )
+
+        with CapturedDescriptor(stream=sys.stderr, threaded=True) as captured:
+            del transaction
+        if captured.text:
+            log.debug("Solver.solve:\n%s", captured.text)
+
+    def _reset(self):
+        self.solver = None
+        self._solver_options = None

--- a/conda_libmamba_solver/libmamba_utils.py
+++ b/conda_libmamba_solver/libmamba_utils.py
@@ -1,0 +1,320 @@
+# Copyright (C) 2019, QuantStack
+# SPDX-License-Identifier: BSD-3-Clause
+
+# TODO: Temporarily vendored from mamba.utils v0.19 on 2021.12.02
+# Decide what to do with it when we split into a plugin
+
+import json
+import os
+import tempfile
+import urllib.parse
+from collections import OrderedDict
+
+from conda.base.constants import ChannelPriority
+from conda.base.context import context
+from conda.common.serialize import json_dump
+from conda.common.url import join_url
+from conda.core.index import _supplement_index_with_system, check_whitelist
+from conda.core.prefix_data import PrefixData
+from conda.gateways.connection.session import CondaHttpAuth
+from conda.models.channel import Channel as CondaChannel
+from conda.models.records import PackageRecord
+
+import libmambapy as api
+
+
+def get_index(
+    channel_urls=(),
+    prepend=True,
+    platform=None,
+    use_local=False,
+    use_cache=False,
+    unknown=None,
+    prefix=None,
+    repodata_fn="repodata.json",
+):
+    if isinstance(platform, str):
+        platform = [platform, "noarch"]
+
+    all_channels = []
+    if use_local:
+        all_channels.append("local")
+    all_channels.extend(channel_urls)
+    if prepend:
+        all_channels.extend(context.channels)
+    check_whitelist(all_channels)
+
+    # Remove duplicates but retain order
+    all_channels = list(OrderedDict.fromkeys(all_channels))
+
+    dlist = api.DownloadTargetList()
+
+    index = []
+
+    def fixup_channel_spec(spec):
+        at_count = spec.count("@")
+        if at_count > 1:
+            first_at = spec.find("@")
+            after_first_at = first_at + 1
+            spec = spec[:first_at] + urllib.parse.quote(spec[first_at]) + spec[after_first_at:]
+        if platform:
+            spec = spec + "[" + ",".join(platform) + "]"
+        return spec
+
+    all_channels = list(map(fixup_channel_spec, all_channels))
+    pkgs_dirs = api.MultiPackageCache(context.pkgs_dirs)
+    api.create_cache_dir(str(pkgs_dirs.first_writable_path))
+
+    for channel in api.get_channels(all_channels):
+        for channel_platform, url in channel.platform_urls(with_credentials=True):
+            full_url = CondaHttpAuth.add_binstar_token(url + "/" + repodata_fn)
+            name = None
+            if channel.name:
+                name = channel.name + "/" + channel_platform
+            else:
+                name = channel.platform_url(channel_platform, with_credentials=False)
+
+            sd = api.SubdirData(
+                name,
+                full_url,
+                api.cache_fn_url(full_url),
+                pkgs_dirs,
+                channel_platform == "noarch",
+            )
+            sd.load()
+
+            index.append((sd, {"platform": channel_platform, "url": url, "channel": channel}))
+            dlist.add(sd)
+
+    is_downloaded = dlist.download(True)
+
+    if not is_downloaded:
+        raise RuntimeError("Error downloading repodata.")
+
+    return index
+
+
+def load_channels(
+    pool,
+    channels,
+    repos,
+    has_priority=None,
+    prepend=True,
+    platform=None,
+    use_local=False,
+    use_cache=True,
+    repodata_fn="repodata.json",
+):
+    index = get_index(
+        channel_urls=channels,
+        prepend=prepend,
+        platform=platform,
+        use_local=use_local,
+        repodata_fn=repodata_fn,
+        use_cache=use_cache,
+    )
+
+    if has_priority is None:
+        has_priority = context.channel_priority in [
+            ChannelPriority.STRICT,
+            ChannelPriority.FLEXIBLE,
+        ]
+
+    subprio_index = len(index)
+    if has_priority:
+        # first, count unique channels
+        n_channels = len(set([entry["channel"].canonical_name for _, entry in index]))
+        current_channel = index[0][1]["channel"].canonical_name
+        channel_prio = n_channels
+
+    for subdir, entry in index:
+        # add priority here
+        if has_priority:
+            if entry["channel"].canonical_name != current_channel:
+                channel_prio -= 1
+                current_channel = entry["channel"].canonical_name
+            priority = channel_prio
+        else:
+            priority = 0
+        if has_priority:
+            # NOTE: -- this is the whole reason we are vendoring this file --
+            # We are patching this from 0 to 1, starting with mamba 0.19
+            # Otherwise, test_create::test_force_remove fails :shrug:
+            subpriority = 1
+        else:
+            subpriority = subprio_index
+            subprio_index -= 1
+
+        if not subdir.loaded() and entry["platform"] != "noarch":
+            # ignore non-loaded subdir if channel is != noarch
+            continue
+
+        if context.verbosity != 0 and not context.json:
+            print(
+                "Channel: {}, platform: {}, prio: {} : {}".format(
+                    entry["channel"], entry["platform"], priority, subpriority
+                )
+            )
+            print("Cache path: ", subdir.cache_path())
+
+        repo = subdir.create_repo(pool)
+        repo.set_priority(priority, subpriority)
+        repos.append(repo)
+
+    return index
+
+
+def init_api_context(verbosity: int = context.verbosity, use_mamba_experimental: bool = False):
+    api_ctx = api.Context()
+
+    api_ctx.json = context.json
+    api_ctx.dry_run = context.dry_run
+    if context.json:
+        context.always_yes = True
+        context.quiet = True
+        if use_mamba_experimental:
+            context.json = False
+
+    # we want verbosity by default, we'll control stdout in our logging
+    # but the file logs will be DEBUG
+    api_ctx.verbosity = verbosity
+    api_ctx.set_verbosity(verbosity)
+    api_ctx.quiet = context.quiet
+    api_ctx.offline = context.offline
+    api_ctx.local_repodata_ttl = context.local_repodata_ttl
+    api_ctx.use_index_cache = context.use_index_cache
+    api_ctx.always_yes = context.always_yes
+    api_ctx.channels = context.channels
+    api_ctx.platform = context.subdir
+
+    if "MAMBA_EXTRACT_THREADS" in os.environ:
+        try:
+            max_threads = int(os.environ["MAMBA_EXTRACT_THREADS"])
+            api_ctx.extract_threads = max_threads
+        except ValueError:
+            v = os.environ["MAMBA_EXTRACT_THREADS"]
+            raise ValueError(
+                f"Invalid conversion of env variable 'MAMBA_EXTRACT_THREADS' from value '{v}'"
+            )
+
+    def get_base_url(url, name=None):
+        tmp = url.rsplit("/", 1)[0]
+        if name:
+            if tmp.endswith(name):
+                return tmp.rsplit("/", 1)[0]
+        return tmp
+
+    api_ctx.channel_alias = str(get_base_url(context.channel_alias.url(with_credentials=True)))
+
+    additional_custom_channels = {}
+    for el in context.custom_channels:
+        if context.custom_channels[el].canonical_name not in ["local", "defaults"]:
+            additional_custom_channels[el] = get_base_url(
+                context.custom_channels[el].url(with_credentials=True), el
+            )
+    api_ctx.custom_channels = additional_custom_channels
+
+    additional_custom_multichannels = {}
+    for el in context.custom_multichannels:
+        if el not in ["defaults", "local"]:
+            additional_custom_multichannels[el] = []
+            for c in context.custom_multichannels[el]:
+                additional_custom_multichannels[el].append(
+                    get_base_url(c.url(with_credentials=True))
+                )
+    api_ctx.custom_multichannels = additional_custom_multichannels
+
+    api_ctx.default_channels = [x.base_url for x in context.default_channels]
+
+    if context.ssl_verify is False:
+        api_ctx.ssl_verify = "<false>"
+    elif context.ssl_verify is not True:
+        api_ctx.ssl_verify = context.ssl_verify
+    api_ctx.target_prefix = context.target_prefix
+    api_ctx.root_prefix = context.root_prefix
+    api_ctx.conda_prefix = context.conda_prefix
+    api_ctx.pkgs_dirs = context.pkgs_dirs
+    api_ctx.envs_dirs = context.envs_dirs
+
+    api_ctx.connect_timeout_secs = int(round(context.remote_connect_timeout_secs))
+    api_ctx.max_retries = context.remote_max_retries
+    api_ctx.retry_backoff = context.remote_backoff_factor
+    api_ctx.add_pip_as_python_dependency = context.add_pip_as_python_dependency
+    api_ctx.use_only_tar_bz2 = context.use_only_tar_bz2
+
+    if context.channel_priority is ChannelPriority.STRICT:
+        api_ctx.channel_priority = api.ChannelPriority.kStrict
+    elif context.channel_priority is ChannelPriority.FLEXIBLE:
+        api_ctx.channel_priority = api.ChannelPriority.kFlexible
+    elif context.channel_priority is ChannelPriority.DISABLED:
+        api_ctx.channel_priority = api.ChannelPriority.kDisabled
+
+    return api_ctx
+
+
+def to_conda_channel(channel, platform):
+    if channel.scheme == "file":
+        return CondaChannel.from_value(channel.platform_url(platform, with_credentials=False))
+
+    return CondaChannel(
+        channel.scheme,
+        channel.auth,
+        channel.location,
+        channel.token,
+        channel.name,
+        platform,
+        channel.package_filename,
+    )
+
+
+def to_package_record_from_subjson(entry, pkg, jsn_string):
+    channel_url = entry["url"]
+    info = json.loads(jsn_string)
+    info["fn"] = pkg
+    info["channel"] = to_conda_channel(entry["channel"], entry["platform"])
+    info["url"] = join_url(channel_url, pkg)
+    package_record = PackageRecord(**info)
+    return package_record
+
+
+# TODO: This one can be deleted once merged
+
+
+def get_installed_packages(prefix, show_channel_urls=None):
+    result = {"packages": {}}
+
+    # Currently, we need to have pip interop disabled :/
+    installed = {rec: rec for rec in PrefixData(prefix, pip_interop_enabled=False).iter_records()}
+
+    # add virtual packages as installed packages
+    # they are packages installed on the system that conda can do nothing
+    # about (e.g. glibc)
+    # if another version is needed, installation just fails
+    # they don't exist anywhere (they start with __)
+    _supplement_index_with_system(installed)
+    installed = list(installed)
+
+    for prec in installed:
+        json_rec = prec.dist_fields_dump()
+        json_rec["depends"] = prec.depends
+        json_rec["constrains"] = prec.constrains
+        json_rec["build"] = prec.build
+        result["packages"][prec.fn] = json_rec
+
+    return installed, result
+
+
+# TODO: This one can be deleted once merged
+
+installed_pkg_recs = None
+
+# TODO: This one can be deleted once merged
+
+
+def get_installed_jsonfile(prefix):
+    global installed_pkg_recs
+    installed_pkg_recs, output = get_installed_packages(prefix, show_channel_urls=True)
+    installed_json_f = tempfile.NamedTemporaryFile("w", delete=False)
+    installed_json_f.write(json_dump(output))
+    installed_json_f.flush()
+    return installed_json_f, installed_pkg_recs

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -1,0 +1,1404 @@
+"""
+Solver-agnostic logic to compose the requests passed to the solver
+and accumulate its results.
+
+The state exposed to the solver is handled by two objects whose primary
+function is to serve read-only information to the solver and its other helpers.
+
+- ``SolverInputState``: fully solver agnostic. It handles:
+    - The local state on disk, namely the prefix state. This includes the
+      already installed packages in the prefix (if any), the explicit requests
+      made in that prefix in the past (history), its pinned specs, packages
+      configured as aggresive updates and others.
+    - The runtime context, determined by the configuration file(s),
+      `CONDA_*` environment variables, command line flags and the requested
+      specs (if any).
+- ``IndexHelper``: can be subclassed to add solver-specific logic
+  (e.g. custom index building). It should, provide, at least, a method to
+  query the index for the _explicit pool_ of packages for a given spec (e.g.
+  its potential dependency tree). Note that the IndexHelper might need
+  pieces of ``SolverInputState`` to build the index (e.g. installed packages,
+  configured channels and subdirs...)
+
+.. todo::
+
+    Embed IndexHelper in SolverInputState?
+
+Since ``conda`` follows an iterative approach to solve a request,
+in addition the _input_ state, the Solver itself can store additional state
+in a separate helper: the ``SolverOutputState`` object. This is meant to help
+accumulate the following pieces of data:
+
+- ``specs``: a mapping of package names to its corresponding ``MatchSpec``
+  objects. These objects are passed to the actual Solver, hoping it will return
+  a solution.
+- ``records``: a mapping of package names to ``PackageRecord`` objects. It will
+  end up containing the list of package records that will compose the final state
+  of the prefix (the _solution_). Its default value is set to the currently installed
+  packages in the prefix. The solver will alter this list as needed to accommodate
+  the final solution.
+
+If the algorithm was not iterative, the sole purpose of the solver would be to turn
+the ``specs`` into ``records``. However, ``conda``'s logic will try to constrain the
+solution to mimic the initial state as much as possible to reduce the amount of
+changes in the prefix. Sometimes, the initial request is too constrained, which results
+in a number of conflicts. These conflicts are then stored in the ``conflicts`` mapping,
+which will determine which ``specs`` are relaxed in the next attempt. Additionally,
+``conda`` stores other solve artifacts:
+
+- ``for_history``: The explicitly requested specs in the command-line should end up
+  in the history. Some modifier flags can affect how this mapping is populated (e.g.
+  ``--update-deps``.)
+- ``neutered``: Pieces of history that were found to be conflicting in the future and
+  were annotated as such to avoid falling in the same conflict again.
+
+The mappings stored in ``SolverOutputState`` are backed by ``TrackedMap`` objects,
+which allow to keep the reasons _why_ those specs or records were added to the mappings,
+as well as richer logging for each action.
+"""
+
+# TODO: This module could be part of conda-core once if we refactor the classic logic
+
+from collections import defaultdict, MutableMapping
+from enum import Enum
+from itertools import chain
+from types import MappingProxyType
+from typing import Any, Hashable, Iterable, Type, Union, Optional, Tuple, Mapping
+from os import PathLike
+import logging
+import sys
+
+from conda. import CondaError
+from conda._vendor.boltons.setutils import IndexedSet
+from conda.auxlib import NULL
+from conda.auxlib.ish import dals
+from conda.base.constants import DepsModifier, UpdateModifier
+from conda.base.context import context
+from conda.common.io import dashlist
+from conda.common.path import get_major_minor_version, paths_equal
+from conda.exceptions import PackagesNotFoundError, SpecsConfigurationConflictError
+from conda.history import History
+from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
+from conda.models.prefix_graph import PrefixGraph
+from conda.core.index import _supplement_index_with_system
+from conda.core.prefix_data import PrefixData
+from conda.core.solve import get_pinned_specs
+
+logger = logging.getLogger(__name__)
+
+
+class TrackedMap(MutableMapping):
+    # TODO: I am sure there's a better place for this object; e.g. conda.models
+    """
+    Implements a dictionary-like interface with self-logging capabilities.
+
+    Each item in the dictionary can be annotated with a ``reason`` of type ``str``.
+    Since a keyword argument is needed, this is only doable via the ``.set()`` method
+    (or any of the derivative methods that call it, like ``.update()``). With normal
+    ``dict`` assignment (à la ``d[key] = value``), ``reason`` will be None.
+
+    Reasons are kept in a dictionary of lists, so a history of reasons is kept for each
+    key present in the dictionary. Reasons for a given ``key`` can be checked with
+    ``.reasons_for(key)``.
+
+    Regardless the value of ``reason``, assignments, updates and deletions will be logged
+    for easy debugging. It is in principle possible to track where each key came from
+    by reading the logs, since the stack level is matched to the originating operation.
+
+    ``.set()`` and ``.update()`` also support an ``overwrite`` boolean option, set to
+    True by default. If False, an existing key will _not_ be overwritten with the
+    new value.
+
+    Parameters
+    ----------
+    name
+        A short identifier for this tracked map. Useful for logging.
+    data
+        Initial data for this object. It can be a dictionary, an iterable of key-value
+        pairs, or another ``TrackedMap`` instance. If given a ``TrackedMap`` instance,
+        its data and reasons will be copied over, instead of wrapped, to avoid recursion.
+    reason
+        Optionally, a reason on why this object was initialized with such data. Ignored
+        if no data is provided.
+
+    Examples
+    --------
+    >>> TrackedMap("example", data={"key": "value"}, reason="Initialization)
+    >>> tm = TrackedMap("example")
+    >>> tm.set("key", "value", reason="First value")
+    >>> tm.update({"another_key": "another_value"}, reason="Second value")
+    >>> tm["third_key"] = "third value"
+    >>> tm[key]
+        "value"
+    >>> tm.reasons_for(key)
+        ["First value"]
+    >>> tm["third_key"]
+        "third value"
+    >>> tm.reasons_for("third_key")
+        [None]
+    """
+
+    def __init__(
+        self,
+        name: str,
+        data: Optional[Union["TrackedMap", Iterable[Iterable], dict]] = None,
+        reason: Optional[str] = None,
+    ):
+        self._name = name
+        self._clsname = self.__class__.__name__
+
+        if isinstance(data, TrackedMap):
+            self._data = data._data.copy()
+            if reason:
+                self._reasons = {k: reason for k in self._data}
+            else:
+                self._reasons = data._reasons.copy()
+        else:
+            self._data = {}
+            self._reasons = defaultdict(list)
+            self.update(data or {}, reason=reason)
+
+    def _set(self, key, value, *, reason: Optional[str] = None, overwrite=True, _level=3):
+        assert isinstance(key, str), f"{key!r} is not str ({reason})"
+        try:
+            old = self._data[key]
+            old_reason = self._reasons.get(key, [None])[-1]
+            msg = (
+                f"{self._clsname}:{self._name}[{key!r}] "
+                f"(={old!r}, reason={old_reason}) updated to {self._short_repr(value)}"
+            )
+            write = overwrite
+        except KeyError:
+            msg = f"{self._clsname}:{self._name}[{key!r}] set to {self._short_repr(value)}"
+            write = True
+
+        if write:
+            if reason:
+                msg += f" (reason={reason})"
+                self._reasons[key].append(reason)
+            self._data[key] = value
+        else:
+            msg = (
+                f"{self._clsname}:{self._name}[{key!r}] "
+                f"(={old!r}, reason={old_reason}) wanted new value {self._short_repr(value)} "
+                f"(reason={reason}) but stayed the same due to overwrite=False."
+            )
+
+        self._log_debug(msg, stacklevel=_level)
+
+    @property
+    def name(self):
+        return self._name
+
+    def __repr__(self):
+        if not self._data:
+            return "{}"
+        lines = ["{"]
+        for k, v in self._data.items():
+            reasons = self._reasons.get(k)
+            reasons = f"  # reasons={reasons}" if reasons else ""
+            lines.append(f"  {k!r}: {v!r},{reasons}")
+        lines.append("}")
+        return "\n".join(lines)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, key: Hashable):
+        return self._data[key]
+
+    def __setitem__(self, key: Hashable, value: Any):
+        self._set(key, value)
+
+    def __delitem__(self, key: Hashable):
+        del self._data[key]
+        self._reasons.pop(key, None)
+        self._log_debug(f"{self._clsname}:{self._name}[{key!r}] was deleted", stacklevel=2)
+
+    def pop(self, key: Hashable, *default: Any, reason: Optional[str] = None) -> Any:
+        """
+        Remove a key-value pair and return the value. A reason can be provided
+        for logging purposes, but it won't be stored in the object.
+        """
+        value = self._data.pop(key, *default)
+        self._reasons.pop(key, *default)
+        msg = f"{self._clsname}:{self._name}[{key!r}] (={self._short_repr(value)}) was deleted"
+        if reason:
+            msg += f" (reason={reason})"
+        self._log_debug(msg, stacklevel=2)
+        return value
+
+    def popitem(
+        self, key: Hashable, *default: Any, reason: Optional[str] = None
+    ) -> Tuple[Hashable, Any]:
+        """
+        Remove and return a key-value pair. A reason can be provided for logging purposes,
+        but it won't be stored in the object.
+        """
+        key, value = self._data.popitem(key)
+        self._reasons.pop(key, *default)
+        msg = f"{self._clsname}:{self._name}[{key!r}] (={self._short_repr(value)}) was deleted"
+        if reason:
+            msg += f" (reason={reason})"
+        self._log_debug(msg, stacklevel=2)
+        return key, value
+
+    def clear(self, reason: Optional[str] = None):
+        """
+        Remove all entries in the map. A reason can be provided for logging purposes,
+        but it won't be stored in the object.
+        """
+        self._data.clear()
+        self._reasons.clear()
+        msg = f"{self._name} was cleared"
+        if reason:
+            msg += f" (reason={reason})"
+        self._log_debug(msg, stacklevel=2)
+
+    def update(
+        self, data: Union[dict, Iterable], *, reason: Optional[str] = None, overwrite: bool = True
+    ):
+        """
+        Update the dictionary with a reason. Note that keyword arguments
+        are not supported in this specific implementation, so you can only
+        update a dictionary with another dictionary or iterable as a
+        positional argument. This is done so `reason` and `overwrite` can
+        be used to control options instead of silently ignoring a potential
+        entry in a ``**kwargs`` argument.
+        """
+        if hasattr(data, "keys"):
+            for k in data.keys():
+                self._set(k, data[k], reason=reason, overwrite=overwrite)
+        else:
+            for k, v in data:
+                self._set(k, v, reason=reason, overwrite=overwrite)
+
+    def set(
+        self, key: Hashable, value: Any, *, reason: Optional[str] = None, overwrite: bool = True
+    ):
+        """
+        Set ``key`` to ``value``, optionally providing a ``reason`` why.
+
+        Parameters
+        ----------
+        key
+            Key to the passed value
+        value
+            Value
+        reason
+            A short description on why this key, value pair was added
+        overwrite
+            If False, do _not_ update the ``value`` for ``key`` if ``key``
+            was already present in the dictionary.
+        """
+        self._set(key, value, reason=reason, overwrite=overwrite)
+
+    def reasons_for(self, key: Hashable) -> Union[Iterable[Union[str, None]], None]:
+        """
+        Return the stored reasons for a given ``key``
+        """
+        return self._reasons.get(key)
+
+    def copy(self):
+        return self.__class__(name=self._name, data=self)
+
+    @staticmethod
+    def _short_repr(value, maxlen=100):
+        value_repr = repr(value)
+        if len(value_repr) > maxlen:
+            value_repr = f"{value_repr[:maxlen-4]}...>"
+        return value_repr
+
+    def _log_debug(self, *args, **kwargs):
+        # stacklevel was only added to logging in py38
+        if sys.version_info < (3, 8):
+            kwargs.pop("stacklevel", None)
+        logger.debug(*args, **kwargs)
+
+
+class EnumAsBools:
+    """
+    Allows an Enum to be bool-evaluated with attribute access.
+
+    >>> update_modifier = UpdateModifier("update_deps")
+    >>> update_modifier_as_bools = EnumAsBools(update_modifier)
+    >>> update_modifier == UpdateModifier.UPDATE_DEPS  # from this
+        True
+    >>> update_modidier_as_bools.UPDATE_DEPS  # to this
+        True
+    >>> update_modifier_as_bools.UPDATE_ALL
+        False
+    """
+
+    def __init__(self, enum: Enum):
+        self._enum = enum
+        self._names = {v.name for v in self._enum.__class__.__members__.values()}
+
+    def __getattr__(self, name: str) -> Any:
+        if name in ("name", "value"):
+            return getattr(self._enum, name)
+        if name in self._names:
+            return self._enum.name == name
+        raise AttributeError(f"'{name}' is not a valid name for {self._enum.__class__.__name__}")
+
+    def __eq__(self, obj: object) -> bool:
+        return self._enum.__eq__(obj)
+
+    def _dict(self):
+        return {name: self._enum.name == name for name in self._names}
+
+
+class IndexHelper:
+    """
+    The _index_ refers to the combination of all configured channels and their
+    platform-corresponding subdirectories. It provides the sources for available
+    packages that can become part of a prefix state, eventually.
+
+    Subclass this helper to add custom repodata fetching if needed.
+    """
+
+    def explicit_pool(self, specs: Iterable[MatchSpec]) -> Iterable[str]:
+        raise NotImplementedError
+
+
+class SolverInputState:
+    # TODO: I am sure there's a better place for this object; e.g. conda.models
+
+    """
+    Helper object to provide the input data needed to compute the state that will be
+    exposed to the solver.
+
+    Parameters
+    ----------
+    prefix
+        Path to the prefix we are operating on. This will be used to expose
+        ``PrefixData``, ``History``, pinned specs, among others.
+    requested
+        The MatchSpec objects required by the user (either in the command line or
+        through the Python API).
+    update_modifier
+        A value of ``UpdateModifier``, which has an effect on which specs are added
+        to the final list. The default value here must match the default value in the
+        ``context`` object.
+    deps_modifier
+        A value of ``DepsModifier``, which has an effect on which specs are added
+        to the final list. The default value here must match the default value in the
+        ``context`` object.
+    ignore_pinned
+        Whether pinned specs can be ignored or not. The default value here must match
+        the default value in the ``context`` object.
+    force_remove
+        Remove the specs without solving the environment (which would also remove their)
+        dependencies. The default value here must match the default value in the
+        ``context`` object.
+    force_reinstall
+        Uninstall and install the computed records even if they were already satisfied
+        in the given prefix. The default value here must match the default value in the
+        ``context`` object.
+    prune
+        Remove dangling dependencies that ended up orphan. The default value here must
+        match the default value in the ``context`` object.
+    command
+        The subcommand used to invoke this operation (e.g. ``create``, ``install``, ``remove``...).
+        It can have an effect on the computed list of records.
+    _pip_interop_enabled
+        Internal only. Whether ``PrefixData`` will also expose packages not installed by
+        ``conda`` (e.g. ``pip`` and others can put Python packages in the prefix).
+    """
+    _ENUM_STR_MAP = {
+        "NOT_SET": DepsModifier.NOT_SET,
+        "NO_DEPS": DepsModifier.NO_DEPS,
+        "ONLY_DEPS": DepsModifier.ONLY_DEPS,
+        "SPECS_SATISFIED_SKIP_SOLVE": UpdateModifier.SPECS_SATISFIED_SKIP_SOLVE,
+        "FREEZE_INSTALLED": UpdateModifier.FREEZE_INSTALLED,
+        "UPDATE_DEPS": UpdateModifier.UPDATE_DEPS,
+        "UPDATE_SPECS": UpdateModifier.UPDATE_SPECS,
+        "UPDATE_ALL": UpdateModifier.UPDATE_ALL,
+    }
+    _DO_NOT_REMOVE_NAMES = (
+        "anaconda",
+        "conda",
+        "conda-build",
+        "python.app",
+        "console_shortcut",
+        "powershell_shortcut",
+    )
+
+    def __init__(
+        self,
+        prefix: Union[str, bytes, PathLike],
+        requested: Optional[Iterable[Union[str, MatchSpec]]] = (),
+        update_modifier: Optional[UpdateModifier] = UpdateModifier.UPDATE_SPECS,
+        deps_modifier: Optional[DepsModifier] = DepsModifier.NOT_SET,
+        ignore_pinned: Optional[bool] = None,
+        force_remove: Optional[bool] = False,
+        force_reinstall: Optional[bool] = False,
+        prune: Optional[bool] = False,
+        command: Optional[str] = None,
+        _pip_interop_enabled: Optional[bool] = None,
+    ):
+        self.prefix = prefix
+        self._prefix_data = PrefixData(prefix, pip_interop_enabled=_pip_interop_enabled)
+        self._pip_interop_enabled = _pip_interop_enabled
+        self._history = History(prefix).get_requested_specs_map()
+        self._pinned = {spec.name: spec for spec in get_pinned_specs(prefix)}
+        self._aggressive_updates = {spec.name: spec for spec in context.aggressive_update_packages}
+
+        virtual = {}
+        _supplement_index_with_system(virtual)
+        self._virtual = {record.name: record for record in virtual}
+
+        self._requested = {}
+        for spec in requested:
+            spec = MatchSpec(spec)
+            self._requested[spec.name] = spec
+
+        self._update_modifier = self._default_to_context_if_null(
+            "update_modifier", update_modifier
+        )
+        self._deps_modifier = self._default_to_context_if_null("deps_modifier", deps_modifier)
+        self._ignore_pinned = self._default_to_context_if_null("ignore_pinned", ignore_pinned)
+        self._force_remove = self._default_to_context_if_null("force_remove", force_remove)
+        self._force_reinstall = self._default_to_context_if_null(
+            "force_reinstall", force_reinstall
+        )
+        self._prune = prune
+        self._command = command
+
+        # special cases
+        self._do_not_remove = {p: MatchSpec(p) for p in self._DO_NOT_REMOVE_NAMES}
+
+        self._check_state()
+
+    def _check_state(self):
+        """
+        Run some consistency checks to ensure configuration is solid.
+        """
+        # Ensure configured pins match installed builds
+        for name, pin_spec in self.pinned.items():
+            installed = self.installed.get(name)
+            if installed and not pin_spec.match(installed):
+                raise SpecsConfigurationConflictError([installed], [pin_spec], self.prefix)
+
+    def _default_to_context_if_null(self, name, value, context=context):
+        "Obtain default value from the context if value is set to NULL; otherwise leave as is"
+        return getattr(context, name) if value is NULL else self._ENUM_STR_MAP.get(value, value)
+
+    @property
+    def prefix_data(self) -> PrefixData:
+        """
+        A direct reference to the ``PrefixData`` object for the given ``prefix``.
+        You will usually use this object through the ``installed`` property.
+        """
+        return self._prefix_data
+
+    # Prefix state pools
+
+    @property
+    def installed(self) -> Mapping[str, PackageRecord]:
+        """
+        This exposes the installed packages in the prefix. Note that a ``PackageRecord``
+        can generate an equivalent ``MatchSpec`` object with ``.to_match_spec()``.
+        """
+        return MappingProxyType(self.prefix_data._prefix_records)
+
+    @property
+    def history(self) -> Mapping[str, MatchSpec]:
+        """
+        These are the specs that the user explicitly asked for in previous operations
+        on the prefix. See :class:`History` for more details.
+        """
+        return MappingProxyType(self._history)
+
+    @property
+    def pinned(self) -> Mapping[str, MatchSpec]:
+        """
+        These specs represent hard constrains on what package versions can be installed
+        on the environment. The packages here returned don't need to be already installed.
+
+        If ``ignore_pinned`` is True, this returns an empty dictionary.
+        """
+        if self.ignore_pinned:
+            return MappingProxyType({})
+        return MappingProxyType(self._pinned)
+
+    @property
+    def virtual(self) -> Mapping[str, MatchSpec]:
+        """
+        System properties exposed as virtual packages (e.g. ``__glibc=2.17``). These packages
+        cannot be (un)installed, they only represent constrains for other packages. By convention,
+        their names start with a double underscore.
+        """
+        return MappingProxyType(self._virtual)
+
+    @property
+    def aggressive_updates(self) -> Mapping[str, MatchSpec]:
+        """
+        Packages that the solver will always try to update. As such, they will never have an
+        associated version or build constrain. Note that the packages here returned do not need to
+        be installed.
+        """
+        return MappingProxyType(self._aggressive_updates)
+
+    @property
+    def do_not_remove(self) -> Mapping[str, MatchSpec]:
+        """
+        Packages that are protected by the solver so they are not accidentally removed. This list
+        is not configurable, but hardcoded for legacy reasons.
+        """
+        return MappingProxyType(self._do_not_remove)
+
+    @property
+    def requested(self) -> Mapping[str, MatchSpec]:
+        """
+        Packages that the user has explicitly asked for in this operation.
+        """
+        return MappingProxyType(self._requested)
+
+    # Types of commands
+
+    @property
+    def is_installing(self) -> bool:
+        """
+        True if the used subcommand was ``install``.
+        """
+        return self._command == "install"
+
+    @property
+    def is_updating(self) -> bool:
+        """
+        True if the used subcommand was ``update``.
+        """
+        return self._command == "update"
+
+    @property
+    def is_creating(self) -> bool:
+        """
+        True if the used subcommand was ``create``.
+        """
+        return self._command == "create"
+
+    @property
+    def is_removing(self) -> bool:
+        """
+        True if the used subcommand was ``remove``.
+        """
+        return self._command == "remove"
+
+    # modifiers
+
+    @property
+    def update_modifier(self) -> EnumAsBools:
+        """
+        Use attribute access to test whether the modifier is set to that value
+
+        >>> update_modifier = EnumAsBools(context.update_modifier)
+        >>> update_modifier.UPDATE_SPECS
+            True
+        >>> update_modifier.UPDATE_DEPS
+            False
+        """
+        return EnumAsBools(self._update_modifier)
+
+    @property
+    def deps_modifier(self) -> EnumAsBools:
+        """
+        Use attribute access to test whether the modifier is set to that value
+
+        >>> deps_modifier = EnumAsBools(context.deps_modifier)
+        >>> deps_modifier.NOT_SET
+            True
+        >>> deps_modifier.DEPS_ONLY
+            False
+        """
+        return EnumAsBools(self._deps_modifier)
+
+    # Other flags
+
+    @property
+    def ignore_pinned(self) -> bool:
+        return self._ignore_pinned
+
+    @property
+    def force_remove(self) -> bool:
+        return self._force_remove
+
+    @property
+    def force_reinstall(self) -> bool:
+        return self._force_reinstall
+
+    @property
+    def prune(self) -> bool:
+        return self._prune
+
+
+class SolverOutputState:
+    # TODO: This object is starting to look _a lot_ like conda.core.solve itself...
+    # Consider merging this with a base class in conda.core.solve
+    """
+    This is the main mutable object we will massage before passing the result of the computation
+    (the ``specs`` mapping) to the solver. It will also store the result of the solve (in
+    ``records``).
+
+    Parameters
+    ----------
+    solver_input_state
+        This instance provides the initial state for the output.
+    specs
+        Mapping of package names to ``MatchSpec`` objects that will override the initialization
+        driven by ``solver_input_state`` (check ``._initialize_specs_from_input_state()`` for more
+        details).
+    records
+        Mapping of package names to ``PackageRecord`` objects. If not provided, it will be
+        initialized from the ``installed`` records in ``solver_input_state``.
+    for_history
+        Mapping of package names to ``MatchSpec`` objects. These specs will be written to
+        the prefix history once the solve is complete. Its default initial value is taken from the
+        explicitly requested packages in the ``solver_input_state`` instance.
+    neutered
+        Mapping of package names to ``MatchSpec`` objects. These specs are also written to
+        the prefix history, as part of the neutered specs. If not provided, their default value is
+        a blank mapping.
+    conflicts
+        If a solve attempt is not successful, conflicting specs are kept here for further
+        relaxation of the version and build constrains. If not provided, their default value is a
+        blank mapping.
+
+    Notes
+    -----
+    Almost all the attributes in this object map package names (``str``) to ``MatchSpec``
+    (_specs_ in short) objects. The only mapping with different values is ``records``, which
+    stores ``PackageRecord`` objects. A quick note on these objects:
+
+    * ``MatchSpec`` objects are a query language for packages, based on the ``PackageRecord``
+      schema. ``PackageRecord`` objects is how packages that are already installed are
+      represented. This is what you get from ``PrefixData.iter_records()``. Since they are
+      related, ``MatchSpec`` objects can be created from a ``PackageRecord`` with
+      ``.to_match_spec()``.
+    * ``MatchSpec`` objects also feature fields like ``target`` and ``optional``. These are,
+      essentially, used by the low-level classic solver (:class:`conda.resolve.Resolve`) to
+      mark specs as items it can optionally play with to satisfy the solver constrains. A
+      ``target`` marked spec is _soft-pinned_ in the sense that the solver will try to satisfy
+      that but it will stop trying if it gets in the way, so you might end up a different
+      version or build. ``optional`` seems to be in the same lines, but maybe the entire spec
+      can be dropped from the request? The key idea here is that these two fields might not be
+      directly usable by the solver, but it might need some custom adaptation. For example, for
+      ``libmamba`` we might need a separate pool that can be configured as a flexible task. See
+      more details in the first comment of ``conda.core.solve.classic.Solver._add_specs``
+    """
+
+    def __init__(
+        self,
+        *,
+        solver_input_state: SolverInputState,
+        specs: Optional[Mapping[str, MatchSpec]] = None,
+        records: Optional[Mapping[str, PackageRecord]] = None,
+        for_history: Optional[Mapping[str, MatchSpec]] = None,
+        neutered: Optional[Mapping[str, MatchSpec]] = None,
+        conflicts: Optional[Mapping[str, MatchSpec]] = None,
+    ):
+        self.solver_input_state: SolverInputState = solver_input_state
+
+        self.records: Mapping[str, PackageRecord] = TrackedMap("records")
+        if records:
+            self.records.update(records, reason="Initialized from explicitly passed arguments")
+        elif solver_input_state.installed:
+            self.records.update(
+                solver_input_state.installed,
+                reason="Initialized from installed packages in prefix",
+            )
+
+        self.specs: Mapping[str, MatchSpec] = TrackedMap("specs")
+        if specs:
+            self.specs.update(specs, reason="Initialized from explicitly passed arguments")
+        else:
+            self._initialize_specs_from_input_state()
+
+        self.for_history: Mapping[str, MatchSpec] = TrackedMap("for_history")
+        if for_history:
+            self.for_history.update(
+                for_history, reason="Initialized from explicitly passed arguments"
+            )
+        elif solver_input_state.requested:
+            self.for_history.update(
+                solver_input_state.requested,
+                reason="Initialized from requested specs in solver input state",
+            )
+
+        self.neutered: Mapping[str, MatchSpec] = TrackedMap(
+            "neutered", data=(neutered or {}), reason="From arguments"
+        )
+
+        # we track conflicts to relax some constrains and help the solver out
+        self.conflicts: Mapping[str, MatchSpec] = TrackedMap(
+            "conflicts", data=(conflicts or {}), reason="From arguments"
+        )
+
+    def _initialize_specs_from_input_state(self):
+        """
+        Provide the initial value for the ``.specs`` mapping. This depends on whether
+        there's a history available (existing prefix) or not (new prefix).
+        """
+        # Initialize specs following conda.core.solve._collect_all_metadata()
+
+        # First initialization depends on whether we have a history to work with or not
+        if self.solver_input_state.history:
+            # add in historically-requested specs
+            self.specs.update(self.solver_input_state.history, reason="As in history")
+            for name, record in self.solver_input_state.installed.items():
+                if name in self.solver_input_state.aggressive_updates:
+                    self.specs.set(
+                        name, MatchSpec(name), reason="Installed and in aggressive updates"
+                    )
+                elif name in self.solver_input_state.do_not_remove:
+                    # these are things that we want to keep even if they're not explicitly
+                    # specified.  This is to compensate for older installers not recording these
+                    # appropriately for them to be preserved.
+                    self.specs.set(
+                        name,
+                        MatchSpec(name),
+                        reason="Installed and protected in do_not_remove",
+                        overwrite=False,
+                    )
+                elif record.subdir == "pypi":
+                    # add in foreign stuff (e.g. from pip) into the specs
+                    # map. We add it so that it can be left alone more. This is a
+                    # declaration that it is manually installed, much like the
+                    # history map. It may still be replaced if it is in conflict,
+                    # but it is not just an indirect dep that can be pruned.
+                    self.specs.set(
+                        name,
+                        MatchSpec(name),
+                        reason="Installed from PyPI; protect from indirect pruning",
+                    )
+        else:
+            # add everything in prefix if we have no history to work with (e.g. with --update-all)
+            self.specs.update(
+                {name: MatchSpec(name) for name in self.solver_input_state.installed},
+                reason="Installed and no history available",
+            )
+
+        # Add virtual packages so they are taken into account by the solver
+        for name in self.solver_input_state.virtual:
+            # we only add a bare name spec here, no constrain! the constrain is only available
+            # in the index, since it will only contain a single value for the virtual package
+            self.specs.set(name, MatchSpec(name), reason="Virtual system", overwrite=False)
+
+    @property
+    def current_solution(self):
+        """
+        Massage currently stored records so they can be returned as the type expected by the
+        solver API. This is what you should return in ``Solver.solve_final_state()``.
+        """
+        return IndexedSet(PrefixGraph(self.records.values()).graph)
+
+    @property
+    def real_specs(self):
+        """
+        Specs that are _not_ virtual.
+        """
+        return {name: spec for name, spec in self.specs.items() if not name.startswith("__")}
+
+    @property
+    def virtual_specs(self):
+        """
+        Specs that are virtual.
+        """
+        return {name: spec for name, spec in self.specs.items() if name.startswith("__")}
+
+    def prepare_specs(self, index: IndexHelper) -> Mapping[str, MatchSpec]:
+        """
+        Main method to populate the ``specs`` mapping. ``index`` is needed only
+        in some cases, and only to call its method ``.explicit_pool()``.
+        """
+        if self.solver_input_state.is_removing:
+            self._prepare_for_remove()
+        else:
+            self._prepare_for_add(index)
+        self._prepare_for_solve()
+        return self.specs
+
+    def _prepare_for_add(self, index: IndexHelper):
+        """
+        This is the core logic for specs processing. In contrast with the ``conda remove``
+        logic, this part is more intricate since it has to deal with details such as the
+        role of the history specs, aggressive updates, pinned packages and the deps / update
+        modifiers.
+
+        Parameters
+        ----------
+        index
+            Needed to query for the dependency tree of potentially conflicting
+            specs.
+        """
+        sis = self.solver_input_state
+
+        # The constructor should have prepared the _basics_ of the specs / records maps. Now we
+        # we will try to refine the version constrains to minimize changes in the environment
+        # whenever possible. Take into account this is done iteratively together with the
+        # solver! self.records starts with the initial prefix state (if any), but acumulates
+        # solution attempts after each retry.
+
+        # ## Refine specs that match currently proposed solution
+        # ## (either prefix as is, or a failed attempt)
+
+        # First, let's see if the current specs are compatible with the current records. They
+        # should be unless something is very wrong with the prefix.
+
+        for name, spec in self.specs.items():
+            record_matches = [record for record in self.records.values() if spec.match(record)]
+
+            if not record_matches:
+                continue  # nothing to refine
+
+            if len(record_matches) != 1:  # something is very wrong!
+                self._raise_incompatible_spec_records(spec, record_matches)
+
+            # ok, now we can start refining
+            record = record_matches[0]
+            if record.is_unmanageable:
+                self.specs.set(
+                    name, record.to_match_spec(), reason="Spec matches unmanageable record"
+                )
+            elif name in sis.aggressive_updates:
+                self.specs.set(
+                    name, MatchSpec(name), reason="Spec matches record in aggressive updates"
+                )
+            elif name not in self.conflicts:
+                # TODO: and (name not in explicit_pool or record in explicit_pool[name]):
+                self.specs.set(
+                    name,
+                    record.to_match_spec(),
+                    reason="Spec matches record in explicit pool for its name",
+                )
+            elif name in sis.history:
+                # if the package was historically requested, we will honor that, but trying to
+                # keep the package as installed
+                #
+                # TODO: JRG: I don't know how mamba will handle _both_ a constrain and a target;
+                # play with priorities?
+                self.specs.set(
+                    name,
+                    MatchSpec(sis.history[name], target=record.dist_str()),
+                    reason="Spec matches record in history",
+                )
+            else:
+                # every other spec that matches something installed will be configured with
+                # only a target This is the case for conflicts, among others
+                self.specs.set(
+                    name, MatchSpec(name, target=record.dist_str()), reason="Spec matches record"
+                )
+
+        # ## Pinnings ###
+
+        # Now let's add the pinnings
+        # We want to pin packages that are
+        # - installed
+        # - requested by the user (if request and pin conflict, request takes precedence)
+        # - a dependency of something requested by the user
+        pin_overrides = set()
+        if sis.pinned:
+            explicit_pool = set(index.explicit_pool(sis.requested.values()))
+        for name, spec in sis.pinned.items():
+            pin = MatchSpec(spec, optional=False)
+            requested = name in sis.requested
+            if name in sis.installed and not requested:
+                self.specs.set(name, pin, reason="Pinned, installed and not requested")
+            elif requested:
+                if sis.requested[name].match(spec):
+                    reason = (
+                        "Pinned, installed and requested; constraining request "
+                        "as pin because they are compatible"
+                    )
+                    self.specs.set(name, pin, reason=reason)
+                    pin_overrides.add(name)
+                else:
+                    reason = (
+                        "Pinned, installed and requested; pin and request "
+                        "are conflicting, so adding user request due to higher precedence"
+                    )
+                    self.specs.set(name, sis.requested[name], reason=reason)
+            elif name in explicit_pool:
+                # TODO: This might be introducing additional specs into the list if the pin
+                # matches a dependency of a request, but that dependency only appears in _some_
+                # of the request variants. For example, package A=2 depends on B, but package
+                # A=3 no longer depends on B. B will be part of A's explicit pool because it
+                # "could" be a dependency. If B happens to be pinned but A=3 ends up being the
+                # one chosen by the solver, then B would be included in the solution when it
+                # shouldn't. It's a corner case but it can happen so we might need to further
+                # restrict the explicit_pool to see. The original logic in the classic solver
+                # checked: `if explicit_pool[s.name] & ssc.r._get_package_pool([s]).get(s.name,
+                # set()):`
+                self.specs.set(
+                    name,
+                    pin,
+                    reason="Pin matches one of the potential dependencies of user requests",
+                )
+            else:
+                logger.warn(
+                    "pinned spec %s conflicts with explicit specs. Overriding pinned spec.", spec
+                )
+
+        # ## Update modifiers ###
+
+        if sis.update_modifier.FREEZE_INSTALLED:
+            for name, record in sis.installed.items():
+                if name in self.conflicts:
+                    # TODO: Investigate why we use to_match_spec() here and other targets use
+                    # dist_str()
+                    self.specs.set(
+                        name,
+                        MatchSpec(name, target=record.to_match_spec(), optional=True),
+                        reason="Relaxing installed because it caused a conflict",
+                    )
+                else:
+                    self.specs.set(name, record.to_match_spec(), reason="Freezing as installed")
+
+        elif sis.update_modifier.UPDATE_ALL:
+            # NOTE: This logic is VERY similar to what we are doing in the class constructor (?)
+            # NOTE: we are REDEFINING the specs acumulated so far
+            old_specs = self.specs._data.copy()
+            self.specs.clear(reason="Redefining from scratch due to --update-all")
+            if sis.history:
+                # history is preferable because it has explicitly installed stuff in it.
+                # that simplifies our solution.
+                for name in sis.history:
+                    if name in sis.pinned:
+                        self.specs.set(
+                            name,
+                            old_specs[name],
+                            reason="Update all, with history, pinned: reusing existing entry",
+                        )
+                    else:
+                        self.specs.set(
+                            name,
+                            MatchSpec(name),
+                            reason="Update all, with history, not pinned: adding spec "
+                            "from history with no constraints",
+                        )
+
+                for name, record in sis.installed.items():
+                    if record.subdir == "pypi":
+                        self.specs.set(
+                            name,
+                            MatchSpec(name),
+                            reason="Update all, with history: treat pip installed "
+                            "stuff as explicitly installed",
+                        )
+            else:
+                for name in sis.installed:
+                    if name in sis.pinned:
+                        self.specs.set(
+                            name,
+                            old_specs[name],
+                            reason="Update all, no history, pinned: reusing existing entry",
+                        )
+                    else:
+                        self.specs.set(
+                            name,
+                            MatchSpec(name),
+                            reason="Update all, no history, not pinned: adding spec from "
+                            "installed with no constraints",
+                        )
+
+        elif sis.update_modifier.UPDATE_SPECS:
+            # this is the default behaviour if no flags are passed
+            # NOTE: This _anticipates_ conflicts; we can also wait for the next attempt and
+            # get the real solver conflicts as part of self.conflicts -- that would simplify
+            # this logic a bit
+
+            # ensure that our self.specs_to_add are not being held back by packages in the env.
+            # This factors in pins and also ignores specs from the history.  It is unfreezing
+            # only for the indirect specs that otherwise conflict with update of the immediate
+            # request:
+            # pinned_requests = []
+            # for name, spec in sis.requested.items():
+            #     if name not in pin_overrides and name in sis.pinned:
+            #         continue
+            #     if name in sis.history:
+            #         continue
+            #     pinned_requests.append(sis.package_has_updates(spec))
+            #     # this ^ needs to be implemented, requires installed pool
+            # conflicts = sis.get_conflicting_specs(self.specs.values(), pinned_requests) or ()
+            for name in self.conflicts:
+                if (
+                    name not in sis.pinned
+                    and name not in sis.history
+                    and name not in sis.requested
+                ):
+                    self.specs.set(name, MatchSpec(name), reason="Relaxed because conflicting")
+
+        # ## Python pinning ###
+
+        # As a business rule, we never want to update python beyond the current minor version,
+        # unless that's requested explicitly by the user (which we actively discourage).
+
+        if "python" in self.records and "python" not in sis.requested:
+            record = self.records["python"]
+            if "python" not in self.conflicts and sis.update_modifier.FREEZE_INSTALLED:
+                self.specs.set(
+                    "python",
+                    record.to_match_spec(),
+                    reason="Freezing python due to business rule, freeze-installed, "
+                    "and no conflicts",
+                )
+            else:
+                # will our prefix record conflict with any explict spec?  If so, don't add
+                # anything here - let python float when it hasn't been explicitly specified
+                spec = self.specs.get("python", MatchSpec("python"))
+                if spec.get("version"):
+                    reason = "Leaving Python pinning as it was calculated so far"
+                else:
+                    reason = "Pinning Python to match installed version"
+                    version = get_major_minor_version(record.version) + ".*"
+                    spec = MatchSpec(spec, version=version)
+
+                # There's a chance the selected version results in a conflict -- detect and
+                # report?
+                # specs = (spec, ) + tuple(sis.requested.values())
+                # if sis.get_conflicting_specs(specs, sis.requested.values()):
+                #     if not sis.installing:  # TODO: repodata checks?
+                #         # raises a hopefully helpful error message
+                #         sis.find_conflicts(specs)  # this might call the solver -- remove?
+                #     else:
+                #         # oops, no message?
+                #         raise RawStrUnsatisfiableError(
+                #             "Couldn't find a Python version that does not conflict..."
+                #         )
+
+                self.specs.set("python", spec, reason=reason)
+
+        # ## Offline and aggressive updates ###
+
+        # For the aggressive_update_packages configuration parameter, we strip any target
+        # that's been set.
+
+        if not context.offline:
+            for name, spec in sis.aggressive_updates.items():
+                if name in self.specs:
+                    self.specs.set(name, spec, reason="Aggressive updates relaxation")
+
+        # ## User requested specs ###
+
+        # add in explicitly requested specs from specs_to_add
+        # this overrides any name-matching spec already in the spec map
+
+        for name, spec in sis.requested.items():
+            if name not in pin_overrides:
+                self.specs.set(name, spec, reason="Explicitly requested by user")
+
+        # ## Conda pinning ###
+
+        # As a business rule, we never want to downgrade conda below the current version,
+        # unless that's requested explicitly by the user (which we actively discourage).
+
+        if (
+            "conda" in self.specs
+            and "conda" in sis.installed
+            and paths_equal(sis.prefix, context.conda_prefix)
+        ):
+            record = sis.installed["conda"]
+            spec = self.specs["conda"]
+            required_version = f">={record.version}"
+            if not spec.get("version"):
+                spec = MatchSpec(spec, version=required_version)
+                reason = "Pinning conda with version greater than currently installed"
+                self.specs.set("conda", spec, reason=reason)
+            if context.auto_update_conda and "conda" not in sis.requested:
+                spec = MatchSpec("conda", version=required_version, target=None)
+                reason = "Pinning conda with version greater than currently installed, auto update"
+                self.specs.set("conda", spec, reason=reason)
+
+        # ## Extra logic ###
+        # this is where we are adding workarounds for mamba difference's in behavior, which
+        # might not belong here as they are solver specific
+
+        # next step -> .prepare_for_solve()
+
+    def _prepare_for_remove(self):
+        "Just add the user requested specs to ``specs``"
+        # This logic is simpler than when we are installing packages
+        self.specs.update(self.solver_input_state.requested, reason="Adding user-requested specs")
+
+    def _prepare_for_solve(self):
+        """
+        Last part of the logic, common to addition and removal of packages. Originally,
+        the legacy logic will also minimize the conflicts here by doing a pre-solve
+        analysis, but so far we have opted for a different approach in libmamba: let the
+        solver try, fail with conflicts, and annotate those as such so they are unconstrained.
+
+        Now, this method only ensures that the pins do not cause conflicts.
+        """
+        # ## Inconsistency analysis ###
+        # here we would call conda.core.solve.classic.Solver._find_inconsistent_packages()
+
+        # ## Check conflicts are only present in .specs
+        conflicting_and_pinned = [
+            str(spec)
+            for name, spec in self.conflicts.items()
+            if name in self.solver_input_state.pinned
+        ]
+        if conflicting_and_pinned:
+            requested = [
+                str(spec)
+                for spec in chain(self.specs, self.solver_input_state.requested)
+                if spec not in conflicting_and_pinned
+            ]
+            raise SpecsConfigurationConflictError(
+                requested_specs=requested,
+                pinned_specs=conflicting_and_pinned,
+                prefix=self.solver_input_state.prefix,
+            )
+
+        # ## Conflict minimization ###
+        # here conda.core.solve.classic.Solver._run_sat() enters a `while conflicting_specs` loop
+        # to neuter some of the specs in self.specs. In other solvers we let the solver run into
+        # them. We might need to add a hook here ?
+
+        # After this, we finally let the solver do its work. It will either finish with a final
+        # state or fail and repopulate the conflicts list in the SolverOutputState object
+
+    def early_exit(self):
+        """
+        Operations that do not need a solver at all and might result in returning early
+        are collected here.
+        """
+        sis = self.solver_input_state
+
+        if sis.is_removing and sis.force_remove:
+            for name, spec in sis.requested.items():
+                for record in sis.installed.values():
+                    if spec.match(record):
+                        self.records.pop(name)
+                        break
+            return self.current_solution
+
+        if sis.update_modifier.SPECS_SATISFIED_SKIP_SOLVE and not sis.is_removing:
+            for name, spec in sis.requested.items():
+                if name not in sis.installed:
+                    break
+            else:
+                # All specs match a package in the current environment.
+                # Return early, with the current solution (at this point, .records is set
+                # to the map of installed packages)
+                return self.current_solution
+
+        # Check we are not trying to remove things that are not installed
+        if sis.is_removing:
+            not_installed = [
+                spec for name, spec in sis.requested.items() if name not in sis.installed
+            ]
+            if not_installed:
+                raise PackagesNotFoundError(not_installed)
+
+    def post_solve(self, solver: Type["Solver"]):
+        """
+        These tasks are performed _after_ the solver has done its work. It essentially
+        post-processes the ``records`` mapping.
+
+        Parameters
+        ----------
+        solver_cls
+            The class used to instantiate the Solver. If not provided, defaults to the one
+            specified in the context configuration.
+
+        Notes
+        -----
+        This method could be solver-agnostic  but unfortunately ``--update-deps`` requires a
+        second solve; that's why this method needs a solver class to be passed as an argument.
+        """
+        # After a solve, we still need to do some refinement
+        sis = self.solver_input_state
+
+        # ## Record history ###
+        # user requested specs need to be annotated in history
+        # we control that in .for_history
+        self.for_history.update(sis.requested, reason="User requested specs recorded to history")
+
+        # ## Neutered ###
+        # annotate overridden history specs so they are written to disk
+        for name, spec in self.specs.items():
+            history_spec = sis.history.get(name)
+            if history_spec and spec.strictness < history_spec.strictness:
+                self.neutered.set(
+                    name, spec, reason="Spec needs less strict constrains than history"
+                )
+
+        # ## Add inconsistent packages back ###
+        # direct result of the inconsistency analysis above
+
+        # ## Deps modifier ###
+        # handle the different modifiers (NO_DEPS, ONLY_DEPS, UPDATE_DEPS)
+        # this might mean removing different records by hand or even calling
+        # the solver a 2nd time
+
+        if sis.deps_modifier.NO_DEPS:
+            # In the NO_DEPS case, we need to start with the original list of packages in the
+            # environment, and then only modify packages that match the requested specs
+            #
+            # Help information notes that use of NO_DEPS is expected to lead to broken
+            # environments.
+            original_state = dict(sis.installed)
+            only_change_these = {}
+            for name, spec in sis.requested.items():
+                for record in self.records.values():
+                    if spec.match(record):
+                        only_change_these[name] = record
+
+            if sis.is_removing:
+                # TODO: This could be a pre-solve task to save time in forced removes?
+                for name in only_change_these:
+                    del original_state[name]
+            else:
+                for name, record in only_change_these.items():
+                    original_state[name] = record
+
+            self.records.clear(reason="Redefining records due to --no-deps")
+            self.records.update(original_state, reason="Redefined records due to --no-deps")
+
+        elif sis.deps_modifier.ONLY_DEPS and not sis.update_modifier.UPDATE_DEPS:
+            # Using a special instance of PrefixGraph to remove youngest child nodes that match
+            # the original requested specs.  It's important to remove only the *youngest* child
+            # nodes, because a typical use might be `conda install --only-deps python=2 flask`,
+            # and in that case we'd want to keep python.
+            #
+            # What are we supposed to do if flask was already in the environment?
+            # We can't be removing stuff here that's already in the environment.
+            #
+            # What should be recorded for the user-requested specs in this case? Probably all
+            # direct dependencies of flask.
+
+            graph = PrefixGraph(self.records.values(), sis.requested.values())
+            # this method below modifies the graph inplace _and_ returns the removed nodes
+            # (like dict.pop())
+            would_remove = graph.remove_youngest_descendant_nodes_with_specs()
+
+            # We need to distinguish the behaviour between `conda remove` and the rest
+            to_remove = []
+            if sis.is_removing:
+                for record in would_remove:
+                    # do not remove records that were not requested but were installed
+                    if record.name not in sis.requested and record.name in sis.installed:
+                        continue
+                    to_remove.append(record.name)
+            else:
+                for record in would_remove:
+                    for dependency in record.depends:
+                        spec = MatchSpec(dependency)
+                        if spec.name not in self.specs:
+                            # following https://github.com/conda/conda/pull/8766
+                            reason = "Recording deps brought by --only-deps as explicit"
+                            self.for_history.set(spec.name, spec, reason=reason)
+                    to_remove.append(record.name)
+
+            for name in to_remove:
+                installed = sis.installed.get(name)
+                if installed:
+                    self.records.set(
+                        name, installed, reason="Restoring originally installed due to --only-deps"
+                    )
+                else:
+                    self.records.pop(
+                        record.name, reason="Excluding from solution due to --only-deps"
+                    )
+
+        elif sis.update_modifier.UPDATE_DEPS:
+            # Here we have to SAT solve again :(  It's only now that we know the dependency
+            # chain of specs_to_add.
+            #
+            # UPDATE_DEPS is effectively making each spec in the dependency chain a
+            # user-requested spec. For all other specs, we drop all information but name, drop
+            # target, and add them to `requested` so it gets recorded in the history file.
+            #
+            # It's like UPDATE_ALL, but only for certain dependency chains.
+            new_specs = TrackedMap("update_deps_specs")
+
+            graph = PrefixGraph(self.records.values())
+            for name, spec in sis.requested.items():
+                record = graph.get_node_by_name(name)
+                for ancestor in graph.all_ancestors(record):
+                    new_specs.set(
+                        ancestor.name,
+                        MatchSpec(ancestor.name),
+                        reason="New specs asked by --update-deps",
+                    )
+
+            # Remove pinned_specs
+            for name, spec in sis.pinned.items():
+                new_specs.pop(
+                    name, None, reason="Exclude pinned packages from --update-deps specs"
+                )
+            # Follow major-minor pinning business rule for python
+            if "python" in new_specs:
+                record = sis.installed["python"]
+                version = ".".join(record.version.split(".")[:2]) + ".*"
+                new_specs.set("python", MatchSpec(name="python", version=version))
+            # Add in the original `requested` on top.
+            new_specs.update(
+                sis.requested, reason="Add original requested specs on top for --update-deps"
+            )
+
+            if sis.is_removing:
+                specs_to_add = ()
+                specs_to_remove = list(new_specs.keys())
+            else:
+                specs_to_add = list(new_specs.values())
+                specs_to_remove = ()
+
+            with context.override("quiet", False):
+                # Create a new solver instance to perform a 2nd solve with deps added We do it
+                # like this to avoid overwriting state accidentally. Instead, we will import
+                # the needed state bits manually.
+                records = solver.__class__(
+                    prefix=solver.prefix,
+                    channels=solver.channels,
+                    subdirs=solver.subdirs,
+                    specs_to_add=specs_to_add,
+                    specs_to_remove=specs_to_remove,
+                    command="recursive_call_for_update_deps",
+                ).solve_final_state(
+                    update_modifier=UpdateModifier.UPDATE_SPECS,  # avoid recursion!
+                    deps_modifier=sis._deps_modifier,
+                    ignore_pinned=sis.ignore_pinned,
+                    force_remove=sis.force_remove,
+                    prune=sis.prune,
+                )
+                records = {record.name: record for record in records}
+
+            self.records.clear(reason="Redefining due to --update-deps")
+            self.records.update(records, reason="Redefined due to --update-deps")
+            self.for_history.clear(reason="Redefining due to --update-deps")
+            self.for_history.update(new_specs, reason="Redefined due to --update-deps")
+
+            # Disable pruning regardless the original value
+            # TODO: Why? Dive in https://github.com/conda/conda/pull/7719
+            sis._prune = False
+
+        # ## Prune ###
+        # remove orphan leaves in the graph
+        if sis.prune:
+            graph = PrefixGraph(list(self.records.values()), self.specs.values())
+            graph.prune()
+            self.records.clear(reason="Pruning")
+            self.records.update({record.name: record for record in graph.graph}, reason="Pruned")
+
+    @staticmethod
+    def _raise_incompatible_spec_records(spec, records):
+        "Raise an error if something is very wrong with the environment"
+        raise CondaError(
+            dals(
+                f"""
+                Conda encountered an error with your environment.  Please report an issue
+                at https://github.com/conda/conda/issues.  In your report, please include
+                the output of 'conda info' and 'conda list' for the active environment, along
+                with the command you invoked that resulted in this error.
+                pkg_name: {spec.name}
+                spec: {spec}
+                matches_for_spec: {dashlist(records, indent=4)}
+                """
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "setuptools >= 42",
+  "wheel",
+  "setuptools_scm[toml]>=3.4"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,27 @@
+[metadata]
+name = conda-libmamba-solver
+version = 0.1.0
+description = The fast mamba solver, now in conda
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Anaconda, Inc.
+author_email = conda@continuum.io
+license = BSD
+license_file = LICENSE
+classifiers =
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+project_urls =
+    homepage = https://github.com/conda-incubator/conda-libmamba-solver
+
+[options]
+packages = find:
+python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
We started this work as a feature branch in `conda/conda`, mainly through this [PR](https://github.com/conda/conda/pull/10881) (and its many children PRs). As we get closer to the release dates, we need to prepare that code for opt-in distribution, which will involve a separate package our users can install next to `conda` in their `base` environment.

In this PR, we will:

- [X] bring the needed code from the aforementioned PR and adjust as necessary
- [ ] add the necessary metadata bits to make it conda-installable
- [ ] add CI workflows