### PR TITLE
add autobuild workflows

### DIFF
--- a/.github/workflows/builds-canary.yaml
+++ b/.github/workflows/builds-canary.yaml
@@ -3,9 +3,9 @@ name: Canary builds
 on:
   workflow_run:
     workflows:
-      - CI tests
+      - CI
     branches:
-      - master
+      - main
     types:
       - completed
 
@@ -32,10 +32,10 @@ jobs:
           fetch-depth: 0
 
       - name: Create and upload canary build
-        uses: conda/actions/canary-release@v22.1.3
+        uses: conda/actions/canary-release@v22.1.4
         with:
           package-name: conda-libmamba-solver
           subdir: ${{ matrix.subdir }}
-          anaconda-org-channel: jaimergp
+          anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ github.event.repository.name }}-dev
-          anaconda-org-token: ${{ secrets.JAIMERGP_ANACONDA_ORG_TOKEN }}
+          anaconda-org-token: ${{ secrets.CONDA_CANARY_ANACONDA_ORG_TOKEN }}

--- a/.github/workflows/builds-canary.yaml
+++ b/.github/workflows/builds-canary.yaml
@@ -16,11 +16,7 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            subdir: linux-64
-          - runner: macos-latest
-            subdir: osx-64
-          - runner: windows-latest
-            subdir: win-64
+            subdir: noarch
     runs-on: ${{ matrix.runner }}
     steps:
       # Clean checkout of specific git ref needed for package metadata version

--- a/.github/workflows/builds-canary.yaml
+++ b/.github/workflows/builds-canary.yaml
@@ -1,0 +1,41 @@
+name: Canary builds
+
+on:
+  workflow_run:
+    workflows:
+      - CI tests
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  build:
+    if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            subdir: linux-64
+          - runner: macos-latest
+            subdir: osx-64
+          - runner: windows-latest
+            subdir: win-64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      # Clean checkout of specific git ref needed for package metadata version
+      # which needs env vars GIT_DESCRIBE_TAG and GIT_BUILD_STR:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0
+
+      - name: Create and upload canary build
+        uses: conda/actions/canary-release@v22.1.3
+        with:
+          package-name: conda-libmamba-solver
+          subdir: ${{ matrix.subdir }}
+          anaconda-org-channel: jaimergp
+          anaconda-org-label: ${{ github.event.repository.name }}-dev
+          anaconda-org-token: ${{ secrets.JAIMERGP_ANACONDA_ORG_TOKEN }}

--- a/.github/workflows/builds-canary.yaml
+++ b/.github/workflows/builds-canary.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create and upload canary build
-        uses: conda/actions/canary-release@v22.1.4
+        uses: conda/actions/canary-release@v22.2.0
         with:
           package-name: conda-libmamba-solver
           subdir: ${{ matrix.subdir }}

--- a/.github/workflows/builds-canary.yaml
+++ b/.github/workflows/builds-canary.yaml
@@ -39,3 +39,5 @@ jobs:
           anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ github.event.repository.name }}-dev
           anaconda-org-token: ${{ secrets.CONDA_CANARY_ANACONDA_ORG_TOKEN }}
+          conda-build-arguments: '--override-channels -c conda-canary/label/conda-conda-pr-11193 -c conda-forge -c defaults'
+

--- a/.github/workflows/builds-review.yaml
+++ b/.github/workflows/builds-review.yaml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create and upload review build
-        uses: conda/actions/canary-release@v22.1.4
+        uses: conda/actions/canary-release@v22.2.0
         with:
           package-name: conda-libmamba-solver
           subdir: ${{ matrix.subdir }}

--- a/.github/workflows/builds-review.yaml
+++ b/.github/workflows/builds-review.yaml
@@ -14,11 +14,7 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            subdir: linux-64
-          - runner: macos-latest
-            subdir: osx-64
-          - runner: windows-latest
-            subdir: win-64
+            subdir: noarch
     runs-on: ${{ matrix.runner }}
     steps:
 

--- a/.github/workflows/builds-review.yaml
+++ b/.github/workflows/builds-review.yaml
@@ -1,0 +1,62 @@
+name: Review builds
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  build:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.label.name == 'build::review'
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            subdir: linux-64
+          - runner: macos-latest
+            subdir: osx-64
+          - runner: windows-latest
+            subdir: win-64
+    runs-on: ${{ matrix.runner }}
+    steps:
+
+      - name: Remove build label
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.CANARY_ACTION_TOKEN }}
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            })
+            const buildLabel = '${{ github.event.label.name }}'
+            const labels = pullRequest.labels.map(label => label.name)
+            const hasBuildLabel = labels.includes(buildLabel)
+            if (hasBuildLabel) {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: context.issue.number,
+                  name: buildLabel,
+                })
+            }
+      # Clean checkout of specific git ref needed for package metadata version
+      # which needs env vars GIT_DESCRIBE_TAG and GIT_BUILD_STR:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0
+
+      - name: Create and upload review build
+        uses: conda/actions/canary-release@v22.1.2
+        with:
+          package-name: conda-libmamba-solver
+          subdir: ${{ matrix.subdir }}
+          anaconda-org-channel: jaimergp
+          anaconda-org-label: '${{ github.event.repository.name }}-pr-${{ github.event.number }}'
+          anaconda-org-token: ${{ secrets.JAIMERGP_ANACONDA_ORG_TOKEN }}
+          comment-headline: 'Review build status'
+          # comment-token: ${{ secrets.CANARY_ACTION_TOKEN }}
+

--- a/.github/workflows/builds-review.yaml
+++ b/.github/workflows/builds-review.yaml
@@ -58,5 +58,6 @@ jobs:
           anaconda-org-label: '${{ github.event.repository.name }}-pr-${{ github.event.number }}'
           anaconda-org-token: ${{ secrets.CONDA_CANARY_ANACONDA_ORG_TOKEN }}
           comment-headline: 'Review build status'
-          # comment-token: ${{ secrets.CANARY_ACTION_TOKEN }}
+          comment-token: ${{ secrets.CANARY_ACTION_TOKEN }}
+          conda-build-arguments: '--override-channels -c conda-canary/label/conda-conda-pr-11193 -c conda-forge -c defaults'
 

--- a/.github/workflows/builds-review.yaml
+++ b/.github/workflows/builds-review.yaml
@@ -50,13 +50,13 @@ jobs:
           fetch-depth: 0
 
       - name: Create and upload review build
-        uses: conda/actions/canary-release@v22.1.2
+        uses: conda/actions/canary-release@v22.1.4
         with:
           package-name: conda-libmamba-solver
           subdir: ${{ matrix.subdir }}
-          anaconda-org-channel: jaimergp
+          anaconda-org-channel: conda-canary
           anaconda-org-label: '${{ github.event.repository.name }}-pr-${{ github.event.number }}'
-          anaconda-org-token: ${{ secrets.JAIMERGP_ANACONDA_ORG_TOKEN }}
+          anaconda-org-token: ${{ secrets.CONDA_CANARY_ANACONDA_ORG_TOKEN }}
           comment-headline: 'Review build status'
           # comment-token: ${{ secrets.CANARY_ACTION_TOKEN }}
 

--- a/conda.recipe/conda_build_config.yaml
+++ b/conda.recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-channel_sources:
-  - conda-canary,conda-forge,defaults

--- a/conda.recipe/conda_build_config.yaml
+++ b/conda.recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_sources:
+  - conda-canary,conda-forge,defaults

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,42 @@
+package:
+  name: "conda-libmamba-solver"
+  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+
+source:
+  # git_url is nice in that it won't capture devenv stuff.  However, it only
+  # captures committed code, so pay attention.
+  git_url: ../
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - flit-core >=3.2,<4
+  run:
+    - python >=3.6
+    - libmambapy
+    - conda >=4.11
+
+test:
+  imports:
+    - conda_libmamba_solver
+  commands:
+    - CONDA_SOLVER_LOGIC=libmamba conda create -n test --dry-run scipy
+
+about:
+  home: https://github.com/conda-incubator/conda-libmamba-solver
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'The fast mamba solver, now in conda!'
+
+extra:
+  recipe-maintainers:
+    - jaimergp
+    - jezdez
+    - wolfv

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: "conda-libmamba-solver"
-  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  version: {{ GIT_DESCRIBE_TAG.lstrip("v") }}.{{ GIT_BUILD_STR }}
 
 source:
   # git_url is nice in that it won't capture devenv stuff.  However, it only

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: "conda-libmamba-solver"
-  version: {{ GIT_DESCRIBE_TAG.lstrip("v") }}.{{ GIT_BUILD_STR }}
+  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
 
 source:
   # git_url is nice in that it won't capture devenv stuff.  However, it only


### PR DESCRIPTION
Copied over from `conda/conda`. Using my own channel for now while we figure out the token policies across organizations.

Not sure if the action used allows to configure channels. I am using `conda_build_config.yaml` for now but I think that's a `conda-smithy` thing?