### PR TITLE
Change stderr capture from pipe to tempfile

### DIFF
--- a/conda_libmamba_solver/mamba_utils.py
+++ b/conda_libmamba_solver/mamba_utils.py
@@ -3,6 +3,7 @@
 
 # TODO: Temporarily vendored from mamba.utils v0.19 on 2021.12.02
 # Decide what to do with it when we split into a plugin
+# 2022.02.15: updated vendored parts to v0.21.2
 
 import json
 import os
@@ -94,7 +95,7 @@ def get_index(
             index.append((sd, {"platform": channel_platform, "url": url, "channel": channel}))
             dlist.add(sd)
 
-    is_downloaded = dlist.download(True)
+    is_downloaded = dlist.download(api.MAMBA_DOWNLOAD_FAILFAST)
 
     if not is_downloaded:
         raise RuntimeError("Error downloading repodata.")
@@ -232,7 +233,9 @@ def init_api_context(verbosity: int = context.verbosity, use_mamba_experimental:
                 )
     api_ctx.custom_multichannels = additional_custom_multichannels
 
-    api_ctx.default_channels = [x.base_url for x in context.default_channels]
+    api_ctx.default_channels = [
+        get_base_url(x.url(with_credentials=True)) for x in context.default_channels
+    ]
 
     if context.ssl_verify is False:
         api_ctx.ssl_verify = "<false>"

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -13,7 +13,7 @@ from typing import Iterable, Mapping, Optional, Union
 from textwrap import dedent
 
 from conda import __version__ as _conda_version
-from conda.base.constants import REPODATA_FN, ChannelPriority, DepsModifier, UpdateModifier
+from conda.base.constants import REPODATA_FN, ChannelPriority, DepsModifier, UpdateModifier, on_win
 from conda.base.context import context
 from conda.common.constants import NULL
 from conda.common.serialize import json_dump, json_load
@@ -213,7 +213,9 @@ class LibMambaSolver(Solver):
 
         # From now on we _do_ require a solver and the index
         with CapturedDescriptor(stream=sys.stderr, threaded=True) as captured:
-            api_ctx = init_api_context(verbosity=3)
+            # FIXME: we can't enable debug on Windows because
+            #        stderr capturing blocks index downloads!
+            api_ctx = init_api_context(verbosity=context.verbosity if on_win else 3)
             index = LibMambaIndexHelper(
                 installed_records=chain(in_state.installed.values(), in_state.virtual.values()),
                 channels=self._channels,

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -3,6 +3,8 @@ import sys
 from io import UnsupportedOperation
 from time import sleep
 from threading import Thread
+import traceback
+import tempfile
 
 
 class CapturedDescriptor:
@@ -10,29 +12,23 @@ class CapturedDescriptor:
     Class used to grab standard output or another stream.
     """
 
-    def __init__(self, stream=sys.stdout, threaded=False, sentinel="\b"):
+    def __init__(self, stream=sys.stdout, threaded=False, sentinel="\0"):
         self._captured_stream = stream
         self._threaded = threaded
         self._sentinel = sentinel
         self.text = ""
-        if sys.platform.startswith("win"):
-            # This method of capturing stderr messes up downloads on libmamba 0.21
-            # Disable until we find a solution
+        try:
+            # Keep a reference to the descriptor we are capturing
+            self._captured_stream_fd = self._captured_stream.fileno()
+        except UnsupportedOperation:
+            # This happens in our tests because we are already
+            # capturing sys.stdout and stderr; if that's the case
+            # make this a noop
             self.start = self._noop
             self.stop = self._noop
         else:
-            try:
-                # Keep a reference to the descriptor we are capturing
-                self._captured_stream_fd = self._captured_stream.fileno()
-            except UnsupportedOperation:
-                # This happens in our tests because we are already
-                # capturing sys.stdout and stderr; if that's the case
-                # make this a noop
-                self.start = self._noop
-                self.stop = self._noop
-            else:
-                # Create a pipe so the stream can be captured:
-                self._pipe_out, self._pipe_in = os.pipe()
+            # Create a pipe so the stream can be captured:
+            self._pipe_out, self._pipe_in = os.pipe()
 
     def __enter__(self):
         self.start()
@@ -66,17 +62,32 @@ class CapturedDescriptor:
         """
         Stop capturing the stream data and save the text in `text`.
         """
-        # Print the escape character to make the _read method stop:
-        self._captured_stream.write(self._sentinel)
-        # Flush the stream to make sure all our data goes in before
-        # the escape character:
-        self._captured_stream.flush()
-        if self._threaded:
-            # wait until the thread finishes so we are sure that
-            # we have the last character:
-            self._thread.join()
+        try:
+            if sys.platform.startswith("win"):
+                os.write(self._pipe_in, self._sentinel.encode())
+                os.fsync(self._pipe_in)
+            else:
+                # Print the escape character to make the _read method stop:
+                self._captured_stream.write(self._sentinel)
+                # Flush the stream to make sure all our data goes in before
+                # the escape character:
+                self._captured_stream.flush()
+            if self._threaded:
+                # wait until the thread finishes so we are sure that
+                # we have the last character:
+                self._thread.join()
+            else:
+                self._read()
+        except Exception as e:
+            traceback.print_exc(file=sys.stdout)
+            self._close()
+            raise
         else:
-            self._read()
+            self._close()
+
+    stop = _stop
+
+    def _close(self):
         # Close the pipe:
         os.close(self._pipe_in)
         os.close(self._pipe_out)
@@ -84,8 +95,6 @@ class CapturedDescriptor:
         os.dup2(self._original_stream_fd, self._captured_stream_fd)
         # Close the duplicate stream:
         os.close(self._original_stream_fd)
-
-    stop = _stop
 
     def _read(self, length=1):
         """
@@ -97,3 +106,45 @@ class CapturedDescriptor:
             if not char or self._sentinel in char:
                 break
             self.text += char
+
+
+class CaptureStreamToFile:
+    def __init__(self, stream=sys.stderr, path=None, callback=None):
+        self._original_stream = stream
+        if path is None:
+            self._file = tempfile.TemporaryFile(mode='w+t')
+        else:
+            self._file = open(path, mode="a+t")
+        self.text = None
+        self._callback = callback
+
+    def start(self):
+        self._original_fileno = self._original_stream.fileno()
+        self._saved_original_fileno = os.dup(self._original_fileno)
+        os.dup2(self._file.fileno(), self._original_fileno)
+
+    def stop(self):
+        os.dup2(self._saved_original_fileno, self._original_fileno)
+        os.close(self._saved_original_fileno)
+        self._file.flush()
+        self._file.seek(0)
+        self.text = self._file.read()
+        self._file.close()
+        if self._callback:
+            self._callback(self.text)
+
+    def __enter__(self):
+        try:
+            self.start()
+            return self
+        except Exception:
+            traceback.print_exception(file=sys.stdout)
+            raise
+
+    def __exit__(self, exc_type, exc_value, tb):
+        try:
+            self.stop()
+        finally:
+            if exc_type is not None:
+                traceback.print_exception(exc_type, exc_value, tb, file=sys.stdout)
+                raise exc_type(exc_value)

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -54,12 +54,11 @@ def test_logging():
     else:
         pytest.fail("Could not find logfile path in outout")
 
-    if not on_win:  # file logging on windows is temporarily disabled :(
-        with open(logfile_path) as f:
-            log_contents = f.read()
-            assert "conda.conda_libmamba_solver" in log_contents
-            assert "solver started" in log_contents
-            assert "choice rule creation took" in log_contents
+    with open(logfile_path) as f:
+        log_contents = f.read()
+        assert "conda.conda_libmamba_solver" in log_contents
+        assert "solver started" in log_contents
+        assert "choice rule creation took" in log_contents
 
 
 def test_cli_flag_in_help():
@@ -113,8 +112,8 @@ def cli_flag_and_env_var_settings():
 
 @pytest.mark.parametrize("name, command, env, solver", cli_flag_and_env_var_settings())
 def test_cli_flag_and_env_var(name, command, env, solver):
-        process = print_and_check_output(command, env=env)
-        if solver == "libmamba":
-            assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in process.stdout
-        else:
-            assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" not in process.stdout
+    process = print_and_check_output(command, env=env)
+    if solver == "libmamba":
+        assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in process.stdout
+    else:
+        assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" not in process.stdout

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -3,13 +3,22 @@ Ensure experimental features work accordingly.
 """
 import os
 import sys
-from subprocess import check_output, STDOUT
+from subprocess import run
 
 import pytest
 
 from conda.base.context import fresh_context, context
 from conda.exceptions import CondaEnvironmentError
 from conda.testing.integration import run_command, Commands, _get_temp_prefix
+
+
+def print_and_check_output(*args, **kwargs):
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("universal_newlines", True)
+    process = run(*args, **kwargs)
+    print("stdout", process.stdout, "---", "stderr", process.stderr, sep="\n")
+    process.check_returncode()
+    return process
 
 
 @pytest.mark.parametrize("solver", ("libmamba", "libmamba-draft"))
@@ -23,13 +32,12 @@ def test_logging():
     "Check we are indeed writing full logs to disk"
     env = os.environ.copy()
     env["CONDA_EXPERIMENTAL_SOLVER"] = "libmamba"
-    stdout = check_output(
+    process = print_and_check_output(
         [sys.executable, "-m", "conda", "create", "-y", "-p", _get_temp_prefix(), "--dry-run", "xz"],
-        env=env, stderr=STDOUT, universal_newlines=True,
+        env=env
     )
-
     in_header = False
-    for line in stdout.splitlines():
+    for line in process.stdout.splitlines():
         line = line.strip()
         if "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in line:
             in_header = True
@@ -59,8 +67,8 @@ def test_cli_flag_in_help():
        ["env", "remove"],
     )
     for command in commands_with_flag:
-        stdout = check_output([sys.executable, "-m", "conda"] + command + ["--help"], stderr=STDOUT, universal_newlines=True)
-        assert "--experimental-solver" in stdout
+        process = print_and_check_output([sys.executable, "-m", "conda"] + command + ["--help"])
+        assert "--experimental-solver" in process.stdout
 
     commands_without_flag = (
        ["config"],
@@ -70,8 +78,8 @@ def test_cli_flag_in_help():
        ["env", "list"],
     )
     for command in commands_without_flag:
-        stdout = check_output([sys.executable, "-m", "conda"] + command + ["--help"], stderr=STDOUT, universal_newlines=True)
-        assert "--experimental-solver" not in stdout
+        process = print_and_check_output([sys.executable, "-m", "conda"] + command + ["--help"])
+        assert "--experimental-solver" not in process.stdout
 
 
 def cli_flag_and_env_var_settings():
@@ -99,9 +107,8 @@ def cli_flag_and_env_var_settings():
 
 @pytest.mark.parametrize("name, command, env, solver", cli_flag_and_env_var_settings())
 def test_cli_flag_and_env_var(name, command, env, solver):
-        stdout = check_output(command, env=env, stderr=STDOUT, universal_newlines=True)
-        print(stdout)
+        process = print_and_check_output(command, env=env)
         if solver == "libmamba":
-            assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in stdout
+            assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in process.stdout
         else:
-            assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" not in stdout
+            assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" not in process.stdout

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -96,9 +96,11 @@ def cli_flag_and_env_var_settings():
     ]
     return tests
 
+
 @pytest.mark.parametrize("name, command, env, solver", cli_flag_and_env_var_settings())
 def test_cli_flag_and_env_var(name, command, env, solver):
         stdout = check_output(command, env=env, stderr=STDOUT, universal_newlines=True)
+        print(stdout)
         if solver == "libmamba":
             assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in stdout
         else:

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -7,6 +7,7 @@ from subprocess import run
 
 import pytest
 
+from conda.base.constants import on_win
 from conda.base.context import fresh_context, context
 from conda.exceptions import CondaEnvironmentError
 from conda.testing.integration import run_command, Commands, _get_temp_prefix
@@ -53,11 +54,12 @@ def test_logging():
     else:
         pytest.fail("Could not find logfile path in outout")
 
-    with open(logfile_path) as f:
-        log_contents = f.read()
-        assert "conda.conda_libmamba_solver" in log_contents
-        assert "solver started" in log_contents
-        assert "choice rule creation took" in log_contents
+    if not on_win:  # file logging on windows is temporarily disabled :(
+        with open(logfile_path) as f:
+            log_contents = f.read()
+            assert "conda.conda_libmamba_solver" in log_contents
+            assert "solver started" in log_contents
+            assert "choice rule creation took" in log_contents
 
 
 def test_cli_flag_in_help():

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -12,6 +12,10 @@ from conda.exceptions import CondaEnvironmentError
 from conda.testing.integration import run_command, Commands, _get_temp_prefix
 
 
+def _get_temp_prefix_safe():
+    return _get_temp_prefix(use_restricted_unicode=True).replace(" ", "")
+
+
 def print_and_check_output(*args, **kwargs):
     kwargs.setdefault("capture_output", True)
     kwargs.setdefault("universal_newlines", True)
@@ -33,7 +37,7 @@ def test_logging():
     env = os.environ.copy()
     env["CONDA_EXPERIMENTAL_SOLVER"] = "libmamba"
     process = print_and_check_output(
-        [sys.executable, "-m", "conda", "create", "-y", "-p", _get_temp_prefix(), "--dry-run", "xz"],
+        [sys.executable, "-m", "conda", "create", "-y", "-p", _get_temp_prefix_safe(), "--dry-run", "xz"],
         env=env
     )
     in_header = False
@@ -88,7 +92,7 @@ def cli_flag_and_env_var_settings():
     env_classic = os.environ.copy()
     env_libmamba["CONDA_EXPERIMENTAL_SOLVER"] = "libmamba"
     env_classic["CONDA_EXPERIMENTAL_SOLVER"] = "classic"
-    command = [sys.executable, "-m", "conda", "create", "-y", "-p", _get_temp_prefix(), "--dry-run", "xz"]
+    command = [sys.executable, "-m", "conda", "create", "-y", "-p", _get_temp_prefix_safe(), "--dry-run", "xz"]
     cli_libmamba = ["--experimental-solver=libmamba"]
     cli_classic = ["--experimental-solver=classic"]
     tests = [


### PR DESCRIPTION
Repodata downloads hangs on Windows if `stderr` is captured via `utils.CapturedDescriptor`. 

I have tried threaded vs not threaded, or even disabling progress bars by setting `CI=1` as an environment variable. It looks like duplicating that stream just blocks that call.

@wolfv - is it possible to have the libraries log to a path of our choice? I think forwarding through `logging` is not feasible on Windows, but at least we can redirect the logged lines from libmamba to a file there.