### PR TITLE
optimize logging a bit

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -43,7 +43,7 @@ from .mamba_utils import (
     mamba_version,
 )
 from .state import SolverInputState, SolverOutputState, IndexHelper
-from .utils import CapturedDescriptor, CaptureStreamToFile
+from .utils import CaptureStreamToFile
 
 log = logging.getLogger(f"conda.{__name__}")
 
@@ -213,7 +213,7 @@ class LibMambaSolver(Solver):
 
         # From now on we _do_ require a solver and the index
         with CaptureStreamToFile(callback=log.debug):
-            api_ctx = init_api_context(verbosity=3)
+            api_ctx = init_api_context(verbosity=max(2, context.verbosity))
             index = LibMambaIndexHelper(
                 installed_records=chain(in_state.installed.values(), in_state.virtual.values()),
                 channels=self._channels,

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -1,122 +1,42 @@
 import os
 import sys
-from io import UnsupportedOperation
-from time import sleep
-from threading import Thread
 import traceback
 import tempfile
-
-
-class CapturedDescriptor:
-    """
-    Class used to grab standard output or another stream.
-    """
-
-    def __init__(self, stream=sys.stdout, threaded=False, sentinel="\0"):
-        self._captured_stream = stream
-        self._threaded = threaded
-        self._sentinel = sentinel
-        self.text = ""
-        try:
-            # Keep a reference to the descriptor we are capturing
-            self._captured_stream_fd = self._captured_stream.fileno()
-        except UnsupportedOperation:
-            # This happens in our tests because we are already
-            # capturing sys.stdout and stderr; if that's the case
-            # make this a noop
-            self.start = self._noop
-            self.stop = self._noop
-        else:
-            # Create a pipe so the stream can be captured:
-            self._pipe_out, self._pipe_in = os.pipe()
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.stop()
-
-    def _noop(self, *args, **kwargs):
-        pass
-
-    def _start(self):
-        """
-        Start capturing the stream data.
-        """
-        self.text = ""
-        # Save a copy of the stream:
-        self._original_stream_fd = os.dup(self._captured_stream_fd)
-        # Replace the original stream with our write pipe:
-        os.dup2(self._pipe_in, self._captured_stream_fd)
-        if self._threaded:
-            # Start thread that will read the stream:
-            self._thread = Thread(target=self._read)
-            self._thread.start()
-            # Make sure that the thread is running and os.read() has executed:
-            sleep(0.01)
-
-    start = _start
-
-    def _stop(self):
-        """
-        Stop capturing the stream data and save the text in `text`.
-        """
-        try:
-            if sys.platform.startswith("win"):
-                os.write(self._pipe_in, self._sentinel.encode())
-                os.fsync(self._pipe_in)
-            else:
-                # Print the escape character to make the _read method stop:
-                self._captured_stream.write(self._sentinel)
-                # Flush the stream to make sure all our data goes in before
-                # the escape character:
-                self._captured_stream.flush()
-            if self._threaded:
-                # wait until the thread finishes so we are sure that
-                # we have the last character:
-                self._thread.join()
-            else:
-                self._read()
-        except Exception as e:
-            traceback.print_exc(file=sys.stdout)
-            self._close()
-            raise
-        else:
-            self._close()
-
-    stop = _stop
-
-    def _close(self):
-        # Close the pipe:
-        os.close(self._pipe_in)
-        os.close(self._pipe_out)
-        # Restore the original stream:
-        os.dup2(self._original_stream_fd, self._captured_stream_fd)
-        # Close the duplicate stream:
-        os.close(self._original_stream_fd)
-
-    def _read(self, length=1):
-        """
-        Read the stream data (one byte at a time)
-        and save the text in `text`.
-        """
-        while True:
-            char = os.read(self._pipe_out, length).decode(self._captured_stream.encoding)
-            if not char or self._sentinel in char:
-                break
-            self.text += char
+from typing import Callable, Optional
 
 
 class CaptureStreamToFile:
-    def __init__(self, stream=sys.stderr, path=None, callback=None):
+    def __init__(
+        self,
+        stream=sys.stderr,
+        path: Optional[str] = None,
+        callback: Optional[Callable] = None,
+        keep: Optional[bool] = False,
+    ):
+        """
+        Capture a stream and forward to a file.
+
+        Parameters
+        ----------
+        stream:
+            Which stream to capture. Usually `sys.stderr`.
+        path:
+            Optional. Path to file in disk. It will be opened with `a+t`. If not
+            provided, a temporary file will be used.
+        callback:
+            A callable that will process the captured text output. It must
+            take a single argument of type `str`.
+        keep:
+            Whether to keep the file contents stored in the `text` attribute.
+        """
         self._original_stream = stream
         if path is None:
-            self._file = tempfile.TemporaryFile(mode='w+t')
+            self._file = tempfile.TemporaryFile(mode="w+t")
         else:
             self._file = open(path, mode="a+t")
         self.text = None
         self._callback = callback
+        self._keep_captured = keep
 
     def start(self):
         self._original_fileno = self._original_stream.fileno()
@@ -126,12 +46,16 @@ class CaptureStreamToFile:
     def stop(self):
         os.dup2(self._saved_original_fileno, self._original_fileno)
         os.close(self._saved_original_fileno)
-        self._file.flush()
-        self._file.seek(0)
-        self.text = self._file.read()
-        self._file.close()
-        if self._callback:
-            self._callback(self.text)
+        try:
+            self._file.flush()
+            self._file.seek(0)
+            if self._keep_captured:
+                self.text = self._file.read()
+            if self._callback:
+                text = self.text if self._keep_captured else self._file.read()
+                self._callback(text)
+        finally:
+            self._file.close()
 
     def __enter__(self):
         try:

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -57,8 +57,8 @@ def test_logging():
     with open(logfile_path) as f:
         log_contents = f.read()
         assert "conda.conda_libmamba_solver" in log_contents
-        assert "solver started" in log_contents
-        assert "choice rule creation took" in log_contents
+        assert "info     Parsing MatchSpec" in log_contents
+        assert "info     Adding job" in log_contents
 
 
 def test_cli_flag_in_help():


### PR DESCRIPTION
Follow up to #8 

`verbosity=3` is just too much output from libsolv (1.5M lines for complex solves), which hurts performance. By default, we will only have `verbosity=2` (wayy less! around 100 lines), but this can be cranked up with `conda`'s verbosity (`-vvv`) if needed.

Example of a "complex" solve with 1M lines of output (if `-vvv` is passed):

```
conda create -n demo napari tensorflow pytorch cudatoolkit=10.2 --override-channels -c conda-forge -c defaults --dry-run --experimental-solver=libmamba
```

---

Note, I also removed `CapturedDescriptor`, which wasn't being used anymore (and caused hangs in previous builds).