### PR TITLE
Ask for user confirmation before using libmamba solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           -e TEST_SPLITS
           -e TEST_GROUP
           -e CONDA_EXPERIMENTAL_SOLVER
+          -e CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION
           ghcr.io/conda/conda-ci:master-linux-python${{ matrix.python-version }}
           bash -c "sudo /opt/conda/condabin/conda install -p /opt/conda --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION: false
+
 jobs:
   linux:
     name: Linux, Python ${{ matrix.python-version }}

--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION: false
+
 jobs:
   linux:
     name: Linux, Python ${{ matrix.python-version }}, ${{ matrix.test-type }}, group ${{ matrix.test-group }}
@@ -81,6 +84,7 @@ jobs:
           -e TEST_SPLITS
           -e TEST_GROUP
           -e CONDA_EXPERIMENTAL_SOLVER
+          -e CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION
           ghcr.io/conda/conda-ci:master-linux-python${{ matrix.python-version }}
           bash -c "sudo /opt/conda/condabin/conda install -p /opt/conda --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -343,12 +343,20 @@ class LibMambaSolver(Solver):
                 confirm_yn(f"{msg}\n{risk}", dry_run=False)
 
                 # update ~/.condarc to no longer prompt
-                with open(user_rc_path, "r+") as fh:
-                    condarc = yaml_round_trip_load(fh.read())
-                    condarc["experimental_solver_confirmation"] = False
-                    fh.seek(0)
-                    fh.write(yaml_round_trip_dump(condarc))
-                reset_context()
+                try:
+                    with open(user_rc_path, "r+") as fh:
+                        condarc = yaml_round_trip_load(fh.read())
+                        condarc["experimental_solver_confirmation"] = False
+                        fh.seek(0)
+                        fh.write(yaml_round_trip_dump(condarc))
+                except OSError as e:
+                    log.warning(
+                        "Failed to set `experimental_solver_confirmation: false` in "
+                        "~/.condarc, is the home directory read-only?"
+                    )
+                    log.debug(e)
+                else:
+                    reset_context()
             else:
                 print(msg)
 

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -332,7 +332,7 @@ class LibMambaSolver(Solver):
                 ---------------------------------------------------------------
                 """
             ).rstrip()
-            if context.experimental_solver_confirmation:
+            if context.experimental_solver_confirmation and not context.dry_run:
                 risk = dedent(
                     """
                     There are risks using this experimental solver since it
@@ -344,7 +344,7 @@ class LibMambaSolver(Solver):
                     Do you wish to proceed
                     """
                 ).rstrip()
-                confirm_yn(f"{msg}\n{risk}", dry_run=False)
+                confirm_yn(f"{msg}\n{risk}")
 
                 # update ~/.condarc to no longer prompt
                 try:

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -48,6 +48,7 @@ from .state import SolverInputState, SolverOutputState, IndexHelper
 from .utils import CaptureStreamToFile
 
 log = logging.getLogger(f"conda.{__name__}")
+BLURB_COUNT = 0
 
 
 class LibMambaIndexHelper(IndexHelper):
@@ -181,6 +182,13 @@ class LibMambaSolver(Solver):
         self.solver = None
         self._solver_options = None
 
+        # Temporary, only during experimental phase to ease debugging
+        global BLURB_COUNT
+        if not BLURB_COUNT:
+            self._print_info()
+            self._check_env_is_base()
+        BLURB_COUNT += 1
+
     def solve_final_state(
         self,
         update_modifier=NULL,
@@ -190,10 +198,6 @@ class LibMambaSolver(Solver):
         force_remove=NULL,
         should_retry_solve=False,
     ):
-        # Temporary, only during experimental phase to ease debugging
-        self._print_info()
-        self._check_env_is_base()
-
         in_state = SolverInputState(
             prefix=self.prefix,
             requested=self.specs_to_add or self.specs_to_remove,

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -333,8 +333,8 @@ class LibMambaSolver(Solver):
                     """
                     There are risks using this experimental solver since it
                     does not always produce identical results as that of the
-                    classical solver. As with any experimental/beta product it
-                    is not recommended to use this in production/critical
+                    classical solver. As with any experimental product it
+                    is *not* recommended to use it in production or critical
                     environments.
 
                     Do you wish to proceed


### PR DESCRIPTION
Part 2/2 resolving https://github.com/conda/conda/issues/11224

Utilizes the `experimental_solver_confirmation` context value (see https://github.com/conda/conda/pull/11282) to determine whether the user has previously acknowledged the risks of running the experimental solver.