### PR TITLE
Revert "Ask for user confirmation before using libmamba solver"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-env:
-  CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION: false
-
 jobs:
   linux:
     name: Linux, Python ${{ matrix.python-version }}
@@ -54,7 +51,6 @@ jobs:
           -e TEST_SPLITS
           -e TEST_GROUP
           -e CONDA_EXPERIMENTAL_SOLVER
-          -e CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION
           ghcr.io/conda/conda-ci:master-linux-python${{ matrix.python-version }}
           bash -c "sudo /opt/conda/condabin/conda install -p /opt/conda --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&

--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -14,9 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-env:
-  CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION: false
-
 jobs:
   linux:
     name: Linux, Python ${{ matrix.python-version }}, ${{ matrix.test-type }}, group ${{ matrix.test-group }}
@@ -84,7 +81,6 @@ jobs:
           -e TEST_SPLITS
           -e TEST_GROUP
           -e CONDA_EXPERIMENTAL_SOLVER
-          -e CONDA_EXPERIMENTAL_SOLVER_CONFIRMATION
           ghcr.io/conda/conda-ci:master-linux-python${{ matrix.python-version }}
           bash -c "sudo /opt/conda/condabin/conda install -p /opt/conda --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -14,11 +14,10 @@ from textwrap import dedent
 
 from conda import __version__ as _conda_version
 from conda.base.constants import REPODATA_FN, ChannelPriority, DepsModifier, UpdateModifier
-from conda.base.context import context, user_rc_path, reset_context
-from conda.cli.common import confirm_yn
+from conda.base.context import context
 from conda.common.constants import NULL
 from conda.common.io import Spinner
-from conda.common.serialize import json_dump, json_load, yaml_round_trip_load, yaml_round_trip_dump
+from conda.common.serialize import json_dump, json_load
 from conda.common.path import paths_equal
 from conda.common.url import (
     escape_channel_url,
@@ -48,7 +47,6 @@ from .state import SolverInputState, SolverOutputState, IndexHelper
 from .utils import CaptureStreamToFile
 
 log = logging.getLogger(f"conda.{__name__}")
-BLURB_COUNT = 0
 
 
 class LibMambaIndexHelper(IndexHelper):
@@ -182,13 +180,6 @@ class LibMambaSolver(Solver):
         self.solver = None
         self._solver_options = None
 
-        # Temporary, only during experimental phase to ease debugging
-        global BLURB_COUNT
-        if not BLURB_COUNT:
-            self._print_info()
-            self._check_env_is_base()
-        BLURB_COUNT += 1
-
     def solve_final_state(
         self,
         update_modifier=NULL,
@@ -198,6 +189,10 @@ class LibMambaSolver(Solver):
         force_remove=NULL,
         should_retry_solve=False,
     ):
+        # Temporary, only during experimental phase to ease debugging
+        self._print_info()
+        self._check_env_is_base()
+
         in_state = SolverInputState(
             prefix=self.prefix,
             requested=self.specs_to_add or self.specs_to_remove,
@@ -319,50 +314,21 @@ class LibMambaSolver(Solver):
 
     def _print_info(self):
         if not context.json and not context.quiet:
-            msg = dedent(
-                f"""
-                ----       USING EXPERIMENTAL LIBMAMBA INTEGRATIONS       ----
-                    This is a highly experimental product. If something is
-                    not working as expected, please submit an issue at
-                    https://github.com/conda/conda and attach the log file
-                    found in the following path. Thank you!
+            print(
+                dedent(
+                    f"""
+                    ----       USING EXPERIMENTAL LIBMAMBA INTEGRATIONS       ----
+                        This is a highly experimental product. If something is
+                        not working as expected, please submit an issue at
+                        https://github.com/conda/conda and attach the log file
+                        found in the following path. Thank you!
 
-                    {context._logfile_path}
+                        {context._logfile_path}
 
-                ---------------------------------------------------------------
-                """
-            ).rstrip()
-            if context.experimental_solver_confirmation and not context.dry_run:
-                risk = dedent(
+                    ---------------------------------------------------------------
                     """
-                    There are risks using this experimental solver since it
-                    does not always produce identical results as that of the
-                    classical solver. As with any experimental product it
-                    is *not* recommended to use it in production or critical
-                    environments.
-
-                    Do you wish to proceed
-                    """
-                ).rstrip()
-                confirm_yn(f"{msg}\n{risk}")
-
-                # update ~/.condarc to no longer prompt
-                try:
-                    with open(user_rc_path, "r+") as fh:
-                        condarc = yaml_round_trip_load(fh.read())
-                        condarc["experimental_solver_confirmation"] = False
-                        fh.seek(0)
-                        fh.write(yaml_round_trip_dump(condarc))
-                except OSError as e:
-                    log.warning(
-                        "Failed to set `experimental_solver_confirmation: false` in "
-                        "~/.condarc, is the home directory read-only?"
-                    )
-                    log.debug(e)
-                else:
-                    reset_context()
-            else:
-                print(msg)
+                )
+            )
 
         log.info("Using experimental libmamba integrations")
         log.info("Logfile path: %s", context._logfile_path)

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -47,6 +47,7 @@ from .state import SolverInputState, SolverOutputState, IndexHelper
 from .utils import CaptureStreamToFile
 
 log = logging.getLogger(f"conda.{__name__}")
+BLURB_COUNT = 0
 
 
 class LibMambaIndexHelper(IndexHelper):
@@ -190,8 +191,11 @@ class LibMambaSolver(Solver):
         should_retry_solve=False,
     ):
         # Temporary, only during experimental phase to ease debugging
-        self._print_info()
-        self._check_env_is_base()
+        global BLURB_COUNT
+        if not BLURB_COUNT:
+            self._print_info()
+            self._check_env_is_base()
+        BLURB_COUNT += 1
 
         in_state = SolverInputState(
             prefix=self.prefix,
@@ -317,15 +321,21 @@ class LibMambaSolver(Solver):
             print(
                 dedent(
                     f"""
-                    ----       USING EXPERIMENTAL LIBMAMBA INTEGRATIONS       ----
-                        This is a highly experimental product. If something is
-                        not working as expected, please submit an issue at
-                        https://github.com/conda/conda and attach the log file
-                        found in the following path. Thank you!
+                    ***
 
-                        {context._logfile_path}
+                    NOTE: You are using the EXPERIMENTAL libmamba solver integration.
 
-                    ---------------------------------------------------------------
+                    If something is not working as expected, please:
+
+                    1. Go to https://github.com/conda/conda/issues/new/choose
+                    2. Choose the "Libmamba Solver Feedback (Experimental Feature)" option
+                    3. Attach the log file found in the following path:
+
+                    {context._logfile_path}
+
+                    Thank you for your help!
+
+                    ***
                     """
                 )
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ addopts = [
   ### These used to be skipped or xfail'd upstream, but we are trying to
   ### keep it clean from this project's specifics
   # Conflict report / analysis is done differently with libmamba.
-  "--deselect=tests/cli/test_cli_install.py::TestCliInstall::test_find_conflicts_called_once",
+  "--deselect=tests/cli/test_cli_install.py::test_find_conflicts_called_once",
   # SolverStateContainer needed
   "--deselect=tests/core/test_solve.py::test_solve_2",
   "--deselect=tests/core/test_solve.py::test_virtual_package_solver",

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -136,6 +136,6 @@ def cli_flag_and_env_var_settings():
 def test_cli_flag_and_env_var(name, command, env, solver):
     process = print_and_check_output(command, env=env)
     if solver == "libmamba":
-        assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in process.stdout
+        assert "You are using the EXPERIMENTAL libmamba solver integration" in process.stdout
     else:
-        assert "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" not in process.stdout
+        assert "You are using the EXPERIMENTAL libmamba solver integration" not in process.stdout

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -52,9 +52,9 @@ def test_logging():
     in_header = False
     for line in process.stdout.splitlines():
         line = line.strip()
-        if "USING EXPERIMENTAL LIBMAMBA INTEGRATIONS" in line:
+        if "You are using the EXPERIMENTAL libmamba solver integration" in line:
             in_header = True
-        elif line.startswith("----------"):
+        elif line.startswith("***"):
             in_header = False
         elif in_header and line.endswith(".log"):
             logfile_path = line


### PR DESCRIPTION
Reverts conda-incubator/conda-libmamba-solver#17. See https://github.com/conda/conda/issues/11303

While this doesn't happen with `conda create`, it does happen with `conda install`, maybe other commands where existing envs are expected.