### PR TITLE
ensure classic solver is used to set up dependencies now that 4.12 is out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
           -e TEST_GROUP
           -e CONDA_EXPERIMENTAL_SOLVER
           ghcr.io/conda/conda-ci:master-linux-python${{ matrix.python-version }}
-          bash -c "sudo /opt/conda/condabin/conda install -p /opt/conda --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
+          bash -c "sudo env CONDA_EXPERIMENTAL_SOLVER=classic \
+                        /opt/conda/condabin/conda install -p /opt/conda \
+                        --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&
                    source /opt/conda-src/dev/linux/bashrc.sh &&
                    /opt/conda/bin/python -m pytest /opt/conda-libmamba-solver-src -vv -m 'not slow'"
@@ -92,6 +94,10 @@ jobs:
       - name: Setup environment
         shell: bash -l {0}
         working-directory: conda
+        env:
+          # with 4.12 out, ensure classic is used to install conda-libmamba-solver deps
+          # otherwise it will error out because it can't be imported yet!
+          CONDA_EXPERIMENTAL_SOLVER: classic
         run: |
           set -euxo pipefail
           # restoring the default for changeps1 to have parity with dev
@@ -157,6 +163,10 @@ jobs:
       - name: Setup environment
         shell: cmd
         working-directory: conda
+        env:
+          # with 4.12 out, ensure classic is used to install conda-libmamba-solver deps
+          # otherwise it will error out because it can't be imported yet!
+          CONDA_EXPERIMENTAL_SOLVER: classic
         run: |
           :: add mamba to requirements
           type ..\conda-libmamba-solver\dev\requirements.txt >> .\tests\requirements.txt

--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -82,7 +82,9 @@ jobs:
           -e TEST_GROUP
           -e CONDA_EXPERIMENTAL_SOLVER
           ghcr.io/conda/conda-ci:master-linux-python${{ matrix.python-version }}
-          bash -c "sudo /opt/conda/condabin/conda install -p /opt/conda --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
+          bash -c "sudo env CONDA_EXPERIMENTAL_SOLVER=classic \
+                        /opt/conda/condabin/conda install -p /opt/conda \
+                        --file /opt/conda-libmamba-solver-src/dev/requirements.txt &&
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&
                    $run_test_cmd"
 
@@ -137,6 +139,10 @@ jobs:
       - name: Setup environment
         shell: bash -l {0}
         working-directory: conda
+        env:
+          # with 4.12 out, ensure classic is used to install conda-libmamba-solver deps
+          # otherwise it will error out because it can't be imported yet!
+          CONDA_EXPERIMENTAL_SOLVER: classic
         run: |
           set -euxo pipefail
           # restoring the default for changeps1 to have parity with dev
@@ -233,6 +239,10 @@ jobs:
       - name: Setup environment
         shell: cmd
         working-directory: conda
+        env:
+          # with 4.12 out, ensure classic is used to install conda-libmamba-solver deps
+          # otherwise it will error out because it can't be imported yet!
+          CONDA_EXPERIMENTAL_SOLVER: classic
         run: |
           :: add mamba to requirements
           type ..\conda-libmamba-solver\dev\requirements.txt >> .\tests\requirements.txt


### PR DESCRIPTION
With 4.12 out, `conda` will recognize `CONDA_EXPERIMENTAL_SOLVER` as a valid config key. Since we were setting it up to `libmamba` globally, the dependency installation steps failed because libmamba was not there yet. 

We temporarily override the global value to ensure that the classic solver is used to set up the correct deps for testing.