### PR TITLE
workaround for star-version specs

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -45,7 +45,7 @@ from .mamba_utils import (
     mamba_version,
 )
 from .state import SolverInputState, SolverOutputState, IndexHelper
-from .utils import CaptureStreamToFile, safe_conda_build_form
+from .utils import CaptureStreamToFile
 
 
 log = logging.getLogger(f"conda.{__name__}")
@@ -310,7 +310,7 @@ class LibMambaSolver(Solver):
             for name, record in out_state.records.items():
                 print(
                     " ",
-                    safe_conda_build_form(record.to_match_spec()),
+                    str(record.to_match_spec()),
                     "# reasons=",
                     out_state.records._reasons.get(name, "<None>"),
                     file=sys.stderr,
@@ -449,7 +449,7 @@ class LibMambaSolver(Solver):
             if name.startswith("__"):
                 continue
             self._check_spec_compat(spec)
-            spec_str = safe_conda_build_form(spec)
+            spec_str = str(spec)
             key = "INSTALL", api.SOLVER_INSTALL
             # ## Low-prio task ###
             if name in out_state.conflicts and name not in protected:
@@ -461,7 +461,7 @@ class LibMambaSolver(Solver):
                 key = "UPDATE", api.SOLVER_UPDATE
                 # ## Protect if installed AND history
                 if name in protected:
-                    installed_spec = safe_conda_build_form(installed.to_match_spec())
+                    installed_spec = str(installed.to_match_spec())
                     tasks[("USERINSTALLED", api.SOLVER_USERINSTALLED)].append(installed_spec)
                     # This is "just" an essential job, so it gets higher priority in the solver
                     # conflict resolution. We do this because these are "protected" packages
@@ -520,7 +520,7 @@ class LibMambaSolver(Solver):
         # Protect history and aggressive updates from being uninstalled if possible
         for name, record in out_state.records.items():
             if name in in_state.history or name in in_state.aggressive_updates:
-                spec = safe_conda_build_form(record.to_match_spec())
+                spec = str(record.to_match_spec())
                 tasks[("USERINSTALLED", api.SOLVER_USERINSTALLED)].append(spec)
 
         # No complications here: delete requested and their deps
@@ -531,7 +531,7 @@ class LibMambaSolver(Solver):
         key = ("ERASE | CLEANDEPS", api.SOLVER_ERASE | api.SOLVER_CLEANDEPS)
         for name, spec in in_state.requested.items():
             self._check_spec_compat(spec)
-            tasks[key].append(safe_conda_build_form(spec))
+            tasks[key].append(str(spec))
 
         return tasks
 

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -520,7 +520,9 @@ class LibMambaSolver(Solver):
         # Protect history and aggressive updates from being uninstalled if possible
         for name, record in out_state.records.items():
             if name in in_state.history or name in in_state.aggressive_updates:
-                spec = str(record.to_match_spec())
+                # MatchSpecs constructed from PackageRecords get parsed too
+                # strictly if exported via str(). Use .conda_build_form() directly.
+                spec = record.to_match_spec().conda_build_form()
                 tasks[("USERINSTALLED", api.SOLVER_USERINSTALLED)].append(spec)
 
         # No complications here: delete requested and their deps

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -223,7 +223,7 @@ class LibMambaSolver(Solver):
             api_ctx = init_api_context(verbosity=max(2, context.verbosity))
             index = LibMambaIndexHelper(
                 installed_records=chain(in_state.installed.values(), in_state.virtual.values()),
-                channels=self._channels,
+                channels=list(dict.fromkeys(chain(self.channels, in_state.channels_from_specs()))),
                 subdirs=self.subdirs,
             )
 
@@ -652,7 +652,13 @@ class LibMambaSolver(Solver):
             del transaction
 
     def _check_spec_compat(self, match_spec):
-        supported = "name", "version", "build"
+        """
+        Make sure we are not silently ingesting MatchSpec fields we are not
+        doing anything with!
+
+        TODO: We currently allow `subdir` but we are not handling it right now.
+        """
+        supported = "name", "version", "build", "channel", "subdir"
         unsupported_but_set = []
         for field in match_spec.FIELD_NAMES:
             value = match_spec.get_raw_value(field)

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -29,6 +29,7 @@ from conda.exceptions import (
     SpecsConfigurationConflictError,
     UnsatisfiableError,
     CondaEnvironmentError,
+    InvalidMatchSpec,
 )
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
@@ -658,9 +659,11 @@ class LibMambaSolver(Solver):
             if value and field not in supported:
                 unsupported_but_set.append(field)
         if unsupported_but_set:
-            raise ValueError(
+            raise InvalidMatchSpec(
+                match_spec,
                 "Libmamba only supports a subset of the MatchSpec interface for now. "
-                f"You can only use {supported}, but you tried to use {unsupported_but_set}."
+                f"You can only use {supported}, but you tried to use "
+                f"{tuple(unsupported_but_set)}.",
             )
 
     def _reset(self):

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -142,6 +142,7 @@ class SolverInputState:
         Internal only. Whether ``PrefixData`` will also expose packages not installed by
         ``conda`` (e.g. ``pip`` and others can put Python packages in the prefix).
     """
+
     _ENUM_STR_MAP = {
         "NOT_SET": DepsModifier.NOT_SET,
         "NO_DEPS": DepsModifier.NO_DEPS,
@@ -367,6 +368,22 @@ class SolverInputState:
     @property
     def prune(self) -> bool:
         return self._prune
+
+    #  Utility methods
+
+    def channels_from_specs(self):
+        """
+        Collect all channels added with the `channel::package=*` syntax. For now,
+        we only collect those specifically requested by the user in the current command
+        (same as conda), but we should investigate whether history keeps channels around
+        too.
+        """
+        channels = []
+        for spec in self.requested.values():
+            channel = spec.get_exact_value("channel")
+            if channel:
+                channels.append(channel)
+        return channels
 
 
 class SolverOutputState:

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -72,18 +72,3 @@ class CaptureStreamToFile:
             if exc_type is not None:
                 traceback.print_exception(exc_type, exc_value, tb, file=sys.stdout)
                 raise exc_type(exc_value)
-
-
-def safe_conda_build_form(match_spec: "conda.models.match_spec.MatchSpec"):
-    """Safe workaround for https://github.com/conda/conda/issues/11347"""
-    kwargs = {"name": match_spec.get_exact_value("name")}
-    version = match_spec.get_raw_value("version")
-    build = match_spec.get_raw_value("build")
-
-    if build:
-        kwargs["build"] = build
-        kwargs["version"] = version or "*"  # this is the key fix
-    elif version:
-        kwargs["version"] = version
-
-    return type(match_spec)(**kwargs).conda_build_form()

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -3,6 +3,11 @@ import sys
 import traceback
 import tempfile
 from typing import Callable, Optional
+from io import UnsupportedOperation
+from logging import getLogger
+
+
+log = getLogger(f"conda.{__name__}")
 
 
 class CaptureStreamToFile:
@@ -37,13 +42,18 @@ class CaptureStreamToFile:
         self.text = None
         self._callback = callback
         self._keep_captured = keep
+        self._started = False
 
     def start(self):
+        self._started = False
         self._original_fileno = self._original_stream.fileno()
         self._saved_original_fileno = os.dup(self._original_fileno)
         os.dup2(self._file.fileno(), self._original_fileno)
+        self._started = True
 
     def stop(self):
+        if not self._started:
+            return
         os.dup2(self._saved_original_fileno, self._original_fileno)
         os.close(self._saved_original_fileno)
         try:
@@ -61,6 +71,8 @@ class CaptureStreamToFile:
         try:
             self.start()
             return self
+        except UnsupportedOperation:
+            log.warning("Cannot capture stream! Bypassing ...", exc_info=True)
         except Exception:
             traceback.print_exception(file=sys.stdout)
             raise

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -3,6 +3,7 @@ import sys
 import traceback
 import tempfile
 from typing import Callable, Optional
+from copy import copy
 
 
 class CaptureStreamToFile:
@@ -72,3 +73,18 @@ class CaptureStreamToFile:
             if exc_type is not None:
                 traceback.print_exception(exc_type, exc_value, tb, file=sys.stdout)
                 raise exc_type(exc_value)
+
+
+def safe_conda_build_form(match_spec: "conda.models.match_spec.MatchSpec"):
+    """Safe workaround for https://github.com/conda/conda/issues/11347"""
+    kwargs = {"name": match_spec.get_exact_value("name")}
+    version = match_spec.get_raw_value("version")
+    build = match_spec.get_raw_value("build")
+
+    if build:
+        kwargs["build"] = build
+        kwargs["version"] = version or "*"  # this is the key fix
+    elif version:
+        kwargs["version"] = version
+
+    return type(match_spec)(**kwargs).conda_build_form()

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -3,7 +3,6 @@ import sys
 import traceback
 import tempfile
 from typing import Callable, Optional
-from copy import copy
 
 
 class CaptureStreamToFile:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,0 +1,31 @@
+import sys
+import json
+from subprocess import check_output
+from conda.testing.integration import _get_temp_prefix
+
+
+def test_channel_matchspec():
+    out = check_output(
+        [
+            sys.executable,
+            "-m",
+            "conda",
+            "create",
+            "-p",
+            _get_temp_prefix(),
+            "--experimental-solver=libmamba",
+            "--json",
+            "--override-channels",
+            "-c",
+            "defaults",
+            "conda-forge::libblas=*=*openblas",
+            "python=3.9",
+        ]
+    )
+    result = json.loads(out)
+    assert result["success"] is True
+    for record in result["actions"]["LINK"]:
+        if record["name"] == "numpy":
+            assert record["channel"] == "conda-forge"
+        elif record["name"] == "python":
+            assert record["channel"] == "pkgs/main"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -27,12 +27,7 @@ env = temp_simple_env
 
 
 @pytest.mark.parametrize(
-    "default_packages",
-    [
-        "",
-        "python,jupyter",
-        "python=3",
-    ],
+    "default_packages", ["", "python,jupyter", "python=3",],
 )
 def test_create_empty(default_packages):
     """

--- a/tests/test_workarounds.py
+++ b/tests/test_workarounds.py
@@ -1,0 +1,26 @@
+import sys
+from subprocess import check_call
+
+
+def test_matchspec_star_version():
+    """
+    Specs like `libblas=*=*mkl` choked on `MatchSpec.conda_build_form()`.
+    We work around that with `.utils.safe_conda_build_form()`.
+    Reported in https://github.com/conda/conda/issues/11347
+    """
+    check_call(
+        [
+            sys.executable,
+            "-m",
+            "conda",
+            "create",
+            "-p",
+            "UNUSED",
+            "--dry-run",
+            "--override-channels",
+            "-c",
+            "conda-test",
+            "--experimental-solver=libmamba",
+            "activate_deactivate_package=*=*0",
+        ]
+    )


### PR DESCRIPTION
Closes https://github.com/conda/conda/issues/11347

Closes https://github.com/conda/conda/issues/11230

***

Specs like `libblas=*=*mkl` get parsed as `MatchSpec(name='libblas', build='*mkl')` (note how `version='*'` was dropped for some reason!). This creates issues with `MatchSpec.conda_build_form()`, which expects `version` to be set if `build` is too. However, `libmamba` also supports another `str` representation (invoked via `.__str__()`) which fixes this problem, and also adds support for `channel::package` syntax. So... win-win?