### PR TITLE
allow development install on docker images

### DIFF
--- a/dev/bashrc_linux.sh
+++ b/dev/bashrc_linux.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 # To be used with the conda/conda CI Docker images, possibly while developing locally
+# This script expects the following volumes to be present:
+# - /opt/conda-src -> repo for conda/conda
+# - /opt/conda-libmamba-src -> repo for conda-incubator/conda-libmamba-solver
+
+set -euo pipefail
 
 sudo /opt/conda/condabin/conda install -y -p /opt/conda \
     --file /opt/conda-libmamba-solver-src/dev/requirements.txt \
-    --file /opt/conda-libmamba-solver-src/tests/requirements.txt && \
-    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv && \
-    source /opt/conda-src/dev/linux/bashrc.sh &&
-    cd /opt/conda-libmamba-solver-src
+    --file /opt/conda-libmamba-solver-src/tests/requirements.txt
+
+cd /opt/conda-libmamba-solver-src
+sudo env FLIT_ROOT_INSTALL=1 /opt/conda/bin/python -m flit install --symlink --deps=none
+
+cd /opt/conda-src
+source /opt/conda-src/dev/linux/bashrc.sh
+
+cd /opt/conda-libmamba-solver-src

--- a/dev/bashrc_linux.sh
+++ b/dev/bashrc_linux.sh
@@ -4,7 +4,11 @@
 # - /opt/conda-src -> repo for conda/conda
 # - /opt/conda-libmamba-src -> repo for conda-incubator/conda-libmamba-solver
 
-set -euo pipefail
+set -e
+restore_e() {
+    set +e
+}
+trap restore_e EXIT
 
 sudo /opt/conda/condabin/conda install -y -p /opt/conda \
     --file /opt/conda-libmamba-solver-src/dev/requirements.txt \
@@ -14,6 +18,9 @@ cd /opt/conda-libmamba-solver-src
 sudo env FLIT_ROOT_INSTALL=1 /opt/conda/bin/python -m flit install --symlink --deps=none
 
 cd /opt/conda-src
+export RUNNING_ON_DEVCONTAINER=${RUNNING_ON_DEVCONTAINER:-}
 source /opt/conda-src/dev/linux/bashrc.sh
 
 cd /opt/conda-libmamba-solver-src
+
+set +e

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 conda-content-trust
 rich
 conda-forge::pytest-xprocess
+flit


### PR DESCRIPTION
Some improvements for the bashrc workflow for Docker image based development. Flit does allow editable installs for pyproject.toml projects!