### PR TITLE
fix escape_channel_url problems

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -20,7 +20,6 @@ from conda.common.io import Spinner
 from conda.common.serialize import json_dump, json_load
 from conda.common.path import paths_equal
 from conda.common.url import (
-    escape_channel_url,
     split_anaconda_token,
     remove_auth,
 )
@@ -45,7 +44,7 @@ from .mamba_utils import (
     mamba_version,
 )
 from .state import SolverInputState, SolverOutputState, IndexHelper
-from .utils import CaptureStreamToFile
+from .utils import CaptureStreamToFile, escape_channel_url
 
 
 log = logging.getLogger(f"conda.{__name__}")


### PR DESCRIPTION
A potential solution for the Windows issues we are seeing. This brings `conda.common.url.escape_channel_url` back to our codebase instead of letting it live on `conda/conda`, where updating it might be trickier. Same code as https://github.com/conda/conda/pull/11416