### PR TITLE
Faster Python version changes

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -255,7 +255,10 @@ class LibMambaSolver(Solver):
     def _solving_loop(
         self, in_state: SolverInputState, out_state: SolverOutputState, index: LibMambaIndexHelper,
     ):
-        for attempt in range(1, max(1, len(in_state.installed)) + 1):
+        max_attempts = max(
+            2, int(os.environ.get("CONDA_LIBMAMBA_MAX_ATTEMPTS", len(in_state.installed))) + 1,
+        )
+        for attempt in range(1, max_attempts):
             log.debug("Starting solver attempt %s", attempt)
             if not context.json and not context.quiet and os.environ.get("EXTRA_DEBUG_TO_STDOUT"):
                 print("----- Starting solver attempt", attempt, "------", file=sys.stderr)

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -452,8 +452,8 @@ class LibMambaSolver(Solver):
         # ## When the Python version changes, this implies all packages depending on
         # ## python will be reinstalled too. This can mean that we'll have to try for every
         # ## installed package to result in a conflict before we get to actually solve everything
-        # ## A workaround is to let all python-depending specs to "float" (no build constrain) if
-        # ## the python version was found to change
+        # ## A workaround is to let all non-noarch python-depending specs to "float" by marking
+        # ## them as a conflict preemptively
         python_version_might_change = False
         installed_python = in_state.installed.get("python")
         to_be_installed_python = out_state.specs.get("python")
@@ -469,8 +469,11 @@ class LibMambaSolver(Solver):
             installed = in_state.installed.get(name)
             key = "INSTALL", api.SOLVER_INSTALL
 
-            ## Fast-track python version changes
+            # Fast-track Python version changes: mark non-noarch Python-depending packages as
+            #  conflicting (see `python_version_might_change` definition above for more details)
             if python_version_might_change and installed is not None:
+                if installed.noarch is not None:
+                    continue
                 for dep in installed.depends:
                     dep_spec = MatchSpec(dep)
                     if dep_spec.name in ("python", "python_abi"):

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -457,7 +457,7 @@ class LibMambaSolver(Solver):
         python_version_might_change = False
         installed_python = in_state.installed.get("python")
         to_be_installed_python = out_state.specs.get("python")
-        if installed_python is not None and to_be_installed_python is not None:
+        if installed_python and to_be_installed_python:
             python_version_might_change = not to_be_installed_python.match(installed_python)
 
         tasks = defaultdict(list)
@@ -494,7 +494,7 @@ class LibMambaSolver(Solver):
                 key = "UPDATE", api.SOLVER_UPDATE
 
                 # ## Protect if installed AND history
-                if name and name in protected:
+                if name in protected:
                     installed_spec = str(installed.to_match_spec())
                     tasks[("USERINSTALLED", api.SOLVER_USERINSTALLED)].append(installed_spec)
                     # This is "just" an essential job, so it gets higher priority in the solver

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -256,7 +256,7 @@ class LibMambaSolver(Solver):
         self, in_state: SolverInputState, out_state: SolverOutputState, index: LibMambaIndexHelper,
     ):
         max_attempts = max(
-            2, int(os.environ.get("CONDA_LIBMAMBA_MAX_ATTEMPTS", len(in_state.installed))) + 1,
+            2, int(os.environ.get("CONDA_LIBMAMBA_SOLVER_MAX_ATTEMPTS", len(in_state.installed))) + 1,
         )
         for attempt in range(1, max_attempts):
             log.debug("Starting solver attempt %s", attempt)
@@ -470,7 +470,7 @@ class LibMambaSolver(Solver):
             key = "INSTALL", api.SOLVER_INSTALL
 
             # Fast-track Python version changes: mark non-noarch Python-depending packages as
-            #  conflicting (see `python_version_might_change` definition above for more details)
+            # conflicting (see `python_version_might_change` definition above for more details)
             if python_version_might_change and installed is not None:
                 if installed.noarch is not None:
                     continue

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -494,7 +494,7 @@ class LibMambaSolver(Solver):
                 key = "UPDATE", api.SOLVER_UPDATE
 
                 # ## Protect if installed AND history
-                if name in protected and name:
+                if name and name in protected:
                     installed_spec = str(installed.to_match_spec())
                     tasks[("USERINSTALLED", api.SOLVER_USERINSTALLED)].append(installed_spec)
                     # This is "just" an essential job, so it gets higher priority in the solver

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -454,6 +454,7 @@ class LibMambaSolver(Solver):
         # ## installed package to result in a conflict before we get to actually solve everything
         # ## A workaround is to let all python-depending specs to "float" (no build constrain) if
         # ## the python version was found to change
+        python_version_might_change = False
         installed_python = in_state.installed.get("python")
         to_be_installed_python = out_state.specs.get("python")
         if installed_python is not None and to_be_installed_python is not None:


### PR DESCRIPTION
Right now, we approach frozen installs like this:

* By default, `conda` tells us to freeze everything
* We try to solve, probably failing
* Parse the exception to know what failed
* Annotate the failure as a conflict, which will be special cases during the solver preparation: conflicting specs are relaxed so the solver can choose different builds / version

This has a problem when a LOT of packages conflict, because we need to try once for each installed package. An example where this happens often is a Python version change: all the installed packages that depend on the old version are potential conflicts! 

Since this is relatively common scenario, this PRs special cases this particular situation and annotates all immediate Python-depending packages (those that explicitly list `python` or `python_abi` in their dependencies) as conflicts (before it happens) when the installed Python cannot be satisfied by the incoming request.

Some rough timings show the difference for the `base` environment of the Docker image used in CI (169 packages):

Before this PR:

```
real    1m46.725s
user    1m45.140s
sys     0m1.814s
```

After this PR:

```
real    0m13.520s
user    0m12.560s
sys     0m0.347s
```

You'll note I also added a special `CONDA_LIBMAMBA_MAX_ATTEMPTS` environment variable to control the number of solving attempts we try for freeze_installed before giving up. It defaults to the number of installed packages to ensure best compatibility with conda's behaviour, but in some cases the user might not care for the sake of performance. This env var is not parsed by the `Context` object - we just take it as is, if present.