### PR TITLE
add black config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ build-backend = "flit_core.buildapi"
 [tool.flit.module]
 name = "conda_libmamba_solver"
 
+[tool.black]
+line-length = 99
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = [


### PR DESCRIPTION
Turns out I had my IDE configured to _always_ use `black -l 99` _if_ no config was present on the repo, so we have been effectively using `line-length = 99` since the inception of the repo.

I guess it doesn't hurt to keep using that setting, officially.

I guess (bis) adding some CI to ensure formatting is correct would help as well.