### PR TITLE
Reduce CI matrix for upstream tests

### DIFF
--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -21,18 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7"]
         test-group: ["1", "2", "3"]
         test-splits: ["3"]
         test-type: ["integration"]
         include:
           - python-version: "3.7"
-            test-type: "unit"
-            test-group: "1"
-          - python-version: "3.8"
-            test-type: "unit"
-            test-group: "1"
-          - python-version: "3.9"
             test-type: "unit"
             test-group: "1"
 
@@ -94,18 +88,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8"]
         test-group: ["1", "2", "3"]
         test-splits: ["3"]
         test-type: ["integration"]
         include:
-          - python-version: "3.7"
-            test-type: "unit"
-            test-group: "1"
           - python-version: "3.8"
-            test-type: "unit"
-            test-group: "1"
-          - python-version: "3.9"
             test-type: "unit"
             test-group: "1"
 
@@ -192,17 +180,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.9"]
         test-group: ["1", "2", "3"]
         test-splits: ["3"]
         test-type: ["integration"]
         include:
-          - python-version: "3.7"
-            test-type: "unit"
-            test-group: "1"
-          - python-version: "3.8"
-            test-type: "unit"
-            test-group: "1"
           - python-version: "3.9"
             test-type: "unit"
             test-group: "1"


### PR DESCRIPTION
In order to reduce the number of simultaneous workers this repo uses for CI, the upstream tests will now run the following OSxPyVer combinations:

* Linux / Python 3.7
* MacOS / Python 3.8
* Windows / Python 3.9

This brings the number of jobs from 46 to 22.

The rest of the CI jobs (our unit tests) are way faster (<10 mins) and do not split jobs, so no need to reduce there.

