### PR TITLE
remove base env protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ If you don't want to use the experimental solver anymore, you can uninstall it w
 $ conda remove conda-libmamba-solver
 ```
 
-### Why can't I use the experimental solver on the `base` environment?
-
-This decision has been made to protect your `base` installation from unexpected changes. This
-package is still in a experimental phase and, as a result, you can only use it in non-base
-environments for now.
-
 ### How do I configure conda to use the experimental solver permanently?
 
 Use the following command:

--- a/conda_libmamba_solver/_libmamba.py
+++ b/conda_libmamba_solver/_libmamba.py
@@ -76,14 +76,6 @@ class LibMambaSolverDraft(Solver):
         if not context.json and not context.quiet:
             print("------ USING EXPERIMENTAL LIBMAMBA INTEGRATIONS ------")
 
-        if "PYTEST_CURRENT_TEST" not in os.environ and paths_equal(
-            self.prefix, context.root_prefix
-        ):
-            raise CondaEnvironmentError(
-                f"{self.__class__.__name__} is not allowed on the base environment during "
-                "the experimental release phase. Try using it on a non-base environment!"
-            )
-
         # 0. Identify strategies
         kwargs = self._merge_signature_flags_with_context(
             update_modifier=update_modifier,

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -260,7 +260,6 @@ class LibMambaSolver(Solver):
         global BLURB_COUNT
         if not BLURB_COUNT:
             self._print_info()
-            self._check_env_is_base()
         BLURB_COUNT += 1
 
         in_state = SolverInputState(
@@ -434,16 +433,6 @@ class LibMambaSolver(Solver):
         log.info("Command: %s", sys.argv)
         log.info("Specs to add: %s", self.specs_to_add)
         log.info("Specs to remove: %s", self.specs_to_remove)
-
-    def _check_env_is_base(self):
-        if "PYTEST_CURRENT_TEST" in os.environ:
-            return
-
-        if paths_equal(self.prefix, context.root_prefix):
-            raise CondaEnvironmentError(
-                f"{self.__class__.__name__} is not allowed on the base environment during "
-                "the experimental release phase. Try using it on a non-base environment!"
-            )
 
     def _setup_solver(self, index: LibMambaIndexHelper):
         self._solver_options = solver_options = [

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -26,6 +26,7 @@ def print_and_check_output(*args, **kwargs):
     return process
 
 
+@pytest.mark.xfail(reason="base protections not enabled anymore")
 @pytest.mark.parametrize("solver", ("libmamba", "libmamba-draft"))
 def test_protection_for_base_env(solver):
     with pytest.raises(CondaEnvironmentError), fresh_context(CONDA_EXPERIMENTAL_SOLVER=solver):


### PR DESCRIPTION
After a few months, we haven't heard from broken environments or similar problems, so it's time we allow the solver to operate on the `base` environment.