### PR TITLE
Improve post-solve performance by reimplementing "conda is outdated" notifications

### DIFF
--- a/conda_libmamba_solver/mamba_utils.py
+++ b/conda_libmamba_solver/mamba_utils.py
@@ -18,10 +18,17 @@ except ImportError:
 from conda.base.constants import ChannelPriority
 from conda.base.context import context
 from conda.common.url import join_url
-from conda.core.index import check_whitelist
 from conda.gateways.connection.session import CondaHttpAuth
 from conda.models.channel import Channel as CondaChannel
 from conda.models.records import PackageRecord
+
+try:
+    from conda.core.index import check_allowlist
+except ImportError:  # conda <4.14
+    # TODO: Remove safeguards in a later release
+    # TODO: Patch repodata of older releases to prevent a newer conda
+    #       where check_whitelist won't be available anymore
+    from conda.core.index import check_whitelist as check_allowlist
 
 import libmambapy as api
 
@@ -49,7 +56,7 @@ def get_index(
     all_channels.extend(channel_urls)
     if prepend:
         all_channels.extend(context.channels)
-    check_whitelist(all_channels)
+    check_allowlist(all_channels)
 
     # Remove duplicates but retain order
     all_channels = list(OrderedDict.fromkeys(all_channels))

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -199,7 +199,7 @@ class LibMambaSolver(Solver):
             out_state = self._solving_loop(in_state, out_state, index)
 
         # Restore intended verbosity to avoid unwanted
-        # "freeing xxxx..." messages when the libmambpy objects are deleted
+        # "freeing xxxx..." messages when the libmambapy objects are deleted
         api_ctx.verbosity = context.verbosity
         api_ctx.set_verbosity(context.verbosity)
 


### PR DESCRIPTION
conda calls `_notify_conda_outdated` _after_ the environment is solved to see if we could have updated conda in that step. Since conda-libmamba-solver only reimplemented `solve_final_state` and that function is called in `solve_for_diff`, we were blindly using it.

It shouldn't have been a problem if this function didn't involve loading all the channels again. In conda classic it's not a problem because `SubdirData` classes cache the channels during the process life, but since `conda-libmamba-solver` loads channels with libmamba, we didn't have that cache and had to load everything again, resulting in 20s of overhead.

What we have done is to reimplement this function so it uses the libmamba-loaded channels. These are only available in the `solve_final_state` method, so we have added a couple of arguments and checks to detect which function is calling it. Not perfect, but simpler than other options. Ideally `conda` classic would define a hook to subclass and override too, but we are not there yet.

Before:

![image](https://user-images.githubusercontent.com/2559438/177982735-028b8d9e-04a9-4aab-b11b-911ec4228412.png)


After:

![image](https://user-images.githubusercontent.com/2559438/177982799-2fa8bf34-1593-4f38-9551-60511f2df3c3.png)
