### PR TITLE
Load repodata from historically used channels (as stored in `PrefixData`)

### DIFF
--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -51,11 +51,14 @@ class LibMambaIndexHelper(IndexHelper):
         # See https://github.com/conda/conda/issues/11790
         channels_from_installed = []
         for record in installed_records:
-            if record.channel.auth or record.channel.token or record.channel.name == "@":
+            if record.channel.auth or record.channel.token:
                 # skip if the channel has authentication info, because
                 # it might cause issues with expired tokens and what not
-                # if the name is @, that means is a virtual package -- skip it too
                 continue
+            if record.channel.name in ("@", "<develop>", "pypi"):
+               # These "channels" are not really channels, more like
+               # metadata placeholders
+               continue
             if record.channel.subdir_url not in channels_from_installed:
                 channels_from_installed.append(record.channel.subdir_url)
         if channels_from_installed:

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -58,8 +58,8 @@ class LibMambaIndexHelper(IndexHelper):
                 continue
             if record.channel.subdir_url not in channels_from_installed:
                 channels_from_installed.append(record.channel.subdir_url)
-        if channels_from_installed:
-            self._channels = [*self._channels, *channels_from_installed]
+        # if channels_from_installed:
+        #     self._channels = [*self._channels, *channels_from_installed]
 
         self._channel_lookup = None
         self._index = self._load_channels()

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -58,8 +58,8 @@ class LibMambaIndexHelper(IndexHelper):
                 continue
             if record.channel.subdir_url not in channels_from_installed:
                 channels_from_installed.append(record.channel.subdir_url)
-        # if channels_from_installed:
-        #     self._channels = [*self._channels, *channels_from_installed]
+        if channels_from_installed:
+            self._channels = [*self._channels, *channels_from_installed]
 
         self._channel_lookup = None
         self._index = self._load_channels()

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -56,9 +56,9 @@ class LibMambaIndexHelper(IndexHelper):
                 # it might cause issues with expired tokens and what not
                 continue
             if record.channel.name in ("@", "<develop>", "pypi"):
-               # These "channels" are not really channels, more like
-               # metadata placeholders
-               continue
+                # These "channels" are not really channels, more like
+                # metadata placeholders
+                continue
             if record.channel.subdir_url not in channels_from_installed:
                 channels_from_installed.append(record.channel.subdir_url)
         if channels_from_installed:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -58,7 +58,7 @@ def test_channels_prefixdata():
 
     See https://github.com/conda/conda/issues/11790
     """
-    with make_temp_env("conda-forge::xz", "python") as prefix:
+    with make_temp_env("conda-forge::xz", "python", use_restricted_unicode=True) as prefix:
         output = check_output(
             [
                 sys.executable,


### PR DESCRIPTION
Closes https://github.com/conda/conda/issues/11790

--- 

I am not sure whether we should go this way, though. I think it's a good idea, but we also need to enable this on `conda/conda`, `mamba` and `micromamba` for better compatibility across the ecosystem.

Authenticated channels are the only blocker here, but it can be either worked around or handled gracefully with good errors.