### PR TITLE
Debug 'conda create --clone --offline' error

### DIFF
--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -48,8 +48,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: jaimergp/conda
-          ref: debug-offline-clone
+          repository: conda/conda
+          ref: 07e9fb58f64482dcc5ff6ebe2854fd4d70073e8d
           path: conda
 
       - name: Define test type and override pytest settings
@@ -115,8 +115,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: jaimergp/conda
-          ref: debug-offline-clone
+          repository: conda/conda
+          ref: 07e9fb58f64482dcc5ff6ebe2854fd4d70073e8d
           path: conda
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -202,8 +202,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: jaimergp/conda
-          ref: debug-offline-clone
+          repository: conda/conda
+          ref: 07e9fb58f64482dcc5ff6ebe2854fd4d70073e8d
           path: conda
 
       - name: Set temp dirs correctly

--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -48,8 +48,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: conda/conda
-          ref: bfcbbf664485906b12961e10afe50cb7ae006a8a
+          repository: jaimergp/conda
+          ref: debug-offline-clone
           path: conda
 
       - name: Define test type and override pytest settings
@@ -115,8 +115,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: conda/conda
-          ref: bfcbbf664485906b12961e10afe50cb7ae006a8a
+          repository: jaimergp/conda
+          ref: debug-offline-clone
           path: conda
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -202,8 +202,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: conda/conda
-          ref: bfcbbf664485906b12961e10afe50cb7ae006a8a
+          repository: jaimergp/conda
+          ref: debug-offline-clone
           path: conda
 
       - name: Set temp dirs correctly

--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: main
+          ref: bfcbbf664485906b12961e10afe50cb7ae006a8a
           path: conda
 
       - name: Define test type and override pytest settings
@@ -116,7 +116,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: main
+          ref: bfcbbf664485906b12961e10afe50cb7ae006a8a
           path: conda
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -203,7 +203,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: main
+          ref: bfcbbf664485906b12961e10afe50cb7ae006a8a
           path: conda
 
       - name: Set temp dirs correctly

--- a/.github/workflows/upstream_ci.yml
+++ b/.github/workflows/upstream_ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: 07e9fb58f64482dcc5ff6ebe2854fd4d70073e8d
+          ref: 7ffe442276775fefcf5f6db8352b420867194832
           path: conda
 
       - name: Define test type and override pytest settings
@@ -116,7 +116,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: 07e9fb58f64482dcc5ff6ebe2854fd4d70073e8d
+          ref: 7ffe442276775fefcf5f6db8352b420867194832
           path: conda
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -203,7 +203,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: 07e9fb58f64482dcc5ff6ebe2854fd4d70073e8d
+          ref: 7ffe442276775fefcf5f6db8352b420867194832
           path: conda
 
       - name: Set temp dirs correctly

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,2 +1,3 @@
 libmambapy>=0.23
 conda>=4.13
+# TODO: Update deps

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,3 +1,5 @@
+# TODO: Update deps
 libmambapy>=0.23
 conda>=4.13
-# TODO: Update deps
+# TMP: remove
+mock

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,2 +1,2 @@
-libmambapy>=0.25
-conda>=22.9
+libmambapy>=0.23
+conda>=4.13

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,2 +1,2 @@
-libmambapy>=0.23
-conda>=4.13
+libmambapy>=0.25
+conda>=22.9


### PR DESCRIPTION
Comes from https://github.com/conda-incubator/conda-libmamba-solver/pull/53#issuecomment-1275003411

Debugging a seemingly unrelated error at #53. `main` CI was all-green 12 days ago for https://github.com/conda/conda/commit/bfcbbf664485906b12961e10afe50cb7ae006a8a. A few commits later this PR landed https://github.com/conda/conda/pull/11591. Let's see if that's what broke the upstream tests. 